### PR TITLE
[GH-5] Implement HTTP transport client for platform communication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/obsyk/obsyk-operator
 go 1.23
 
 require (
+	github.com/go-logr/logr v1.4.1
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
@@ -16,7 +17,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -1,0 +1,220 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	// API endpoints
+	endpointSnapshot  = "/api/v1/agents/snapshot"
+	endpointEvents    = "/api/v1/agents/events"
+	endpointHeartbeat = "/api/v1/agents/heartbeat"
+
+	// Default timeouts
+	defaultTimeout = 30 * time.Second
+
+	// Retry configuration
+	maxRetries        = 5
+	initialBackoff    = 1 * time.Second
+	maxBackoff        = 60 * time.Second
+	backoffMultiplier = 2.0
+	jitterFactor      = 0.1
+)
+
+// Client handles HTTP communication with the Obsyk platform.
+type Client struct {
+	httpClient  *http.Client
+	platformURL string
+	apiKey      string
+	log         logr.Logger
+}
+
+// ClientConfig holds configuration for creating a new Client.
+type ClientConfig struct {
+	PlatformURL string
+	APIKey      string
+	Timeout     time.Duration
+	Logger      logr.Logger
+}
+
+// NewClient creates a new transport client.
+func NewClient(cfg ClientConfig) *Client {
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		platformURL: cfg.PlatformURL,
+		apiKey:      cfg.APIKey,
+		log:         cfg.Logger,
+	}
+}
+
+// UpdateAPIKey updates the API key used for authentication.
+// This is useful when the key is refreshed from the Secret.
+func (c *Client) UpdateAPIKey(apiKey string) {
+	c.apiKey = apiKey
+}
+
+// SendSnapshot sends a full cluster state snapshot to the platform.
+func (c *Client) SendSnapshot(ctx context.Context, payload *SnapshotPayload) error {
+	return c.sendWithRetry(ctx, endpointSnapshot, payload)
+}
+
+// SendEvent sends a single resource change event to the platform.
+func (c *Client) SendEvent(ctx context.Context, payload *EventPayload) error {
+	return c.sendWithRetry(ctx, endpointEvents, payload)
+}
+
+// SendHeartbeat sends a periodic health check to the platform.
+func (c *Client) SendHeartbeat(ctx context.Context, payload *HeartbeatPayload) error {
+	return c.sendWithRetry(ctx, endpointHeartbeat, payload)
+}
+
+// sendWithRetry sends a request with exponential backoff retry for server errors.
+func (c *Client) sendWithRetry(ctx context.Context, endpoint string, payload interface{}) error {
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := c.calculateBackoff(attempt)
+			c.log.V(1).Info("retrying request",
+				"endpoint", endpoint,
+				"attempt", attempt+1,
+				"backoff", backoff.String())
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		err := c.send(ctx, endpoint, payload)
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if error is retryable (5xx server errors)
+		if !isRetryableError(err) {
+			c.log.Error(err, "non-retryable error", "endpoint", endpoint)
+			return err
+		}
+
+		c.log.V(1).Info("retryable error occurred",
+			"endpoint", endpoint,
+			"attempt", attempt+1,
+			"error", err.Error())
+	}
+
+	return fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
+// send performs the actual HTTP request.
+func (c *Client) send(ctx context.Context, endpoint string, payload interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling payload: %w", err)
+	}
+
+	url := c.platformURL + endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("User-Agent", "obsyk-operator/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body for error messages
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	// Create appropriate error based on status code
+	switch {
+	case resp.StatusCode >= 500:
+		return &ServerError{
+			StatusCode: resp.StatusCode,
+			Message:    string(respBody),
+		}
+	case resp.StatusCode >= 400:
+		return &ClientError{
+			StatusCode: resp.StatusCode,
+			Message:    string(respBody),
+		}
+	default:
+		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// calculateBackoff returns the backoff duration for a given retry attempt.
+func (c *Client) calculateBackoff(attempt int) time.Duration {
+	// Exponential backoff: initialBackoff * multiplier^attempt
+	backoff := float64(initialBackoff) * math.Pow(backoffMultiplier, float64(attempt))
+
+	// Cap at max backoff
+	if backoff > float64(maxBackoff) {
+		backoff = float64(maxBackoff)
+	}
+
+	// Add jitter (±10%)
+	jitter := backoff * jitterFactor * (2*rand.Float64() - 1)
+	backoff += jitter
+
+	return time.Duration(backoff)
+}
+
+// ServerError represents a 5xx server error (retryable).
+type ServerError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ServerError) Error() string {
+	return fmt.Sprintf("server error %d: %s", e.StatusCode, e.Message)
+}
+
+// ClientError represents a 4xx client error (not retryable).
+type ClientError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ClientError) Error() string {
+	return fmt.Sprintf("client error %d: %s", e.StatusCode, e.Message)
+}
+
+// isRetryableError returns true if the error should trigger a retry.
+func isRetryableError(err error) bool {
+	_, ok := err.(*ServerError)
+	return ok
+}

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -1,0 +1,314 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func TestClient_SendSnapshot(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse int
+		serverBody     string
+		wantErr        bool
+		errType        string
+	}{
+		{
+			name:           "success",
+			serverResponse: http.StatusOK,
+			wantErr:        false,
+		},
+		{
+			name:           "created",
+			serverResponse: http.StatusCreated,
+			wantErr:        false,
+		},
+		{
+			name:           "client error",
+			serverResponse: http.StatusBadRequest,
+			serverBody:     "invalid payload",
+			wantErr:        true,
+			errType:        "client",
+		},
+		{
+			name:           "unauthorized",
+			serverResponse: http.StatusUnauthorized,
+			serverBody:     "invalid api key",
+			wantErr:        true,
+			errType:        "client",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if r.URL.Path != endpointSnapshot {
+					t.Errorf("expected %s, got %s", endpointSnapshot, r.URL.Path)
+				}
+				if r.Header.Get("Authorization") != "Bearer test-api-key" {
+					t.Errorf("missing or invalid Authorization header")
+				}
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("missing Content-Type header")
+				}
+
+				w.WriteHeader(tt.serverResponse)
+				if tt.serverBody != "" {
+					w.Write([]byte(tt.serverBody))
+				}
+			}))
+			defer server.Close()
+
+			client := NewClient(ClientConfig{
+				PlatformURL: server.URL,
+				APIKey:      "test-api-key",
+				Logger:      logr.Discard(),
+			})
+
+			payload := &SnapshotPayload{
+				ClusterName: "test-cluster",
+				ClusterUID:  "test-uid",
+				Timestamp:   time.Now(),
+			}
+
+			err := client.SendSnapshot(context.Background(), payload)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				if tt.errType == "client" {
+					if _, ok := err.(*ClientError); !ok {
+						t.Errorf("expected ClientError, got %T", err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestClient_SendEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointEvents {
+			t.Errorf("expected %s, got %s", endpointEvents, r.URL.Path)
+		}
+
+		var payload EventPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("failed to decode payload: %v", err)
+		}
+
+		if payload.EventType != EventTypeAdded {
+			t.Errorf("expected event type ADDED, got %s", payload.EventType)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		PlatformURL: server.URL,
+		APIKey:      "test-api-key",
+		Logger:      logr.Discard(),
+	})
+
+	payload := &EventPayload{
+		ClusterName:  "test-cluster",
+		ClusterUID:   "test-uid",
+		Timestamp:    time.Now(),
+		EventType:    EventTypeAdded,
+		ResourceType: ResourceTypePod,
+		Resource:     map[string]string{"name": "test-pod"},
+	}
+
+	err := client.SendEvent(context.Background(), payload)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_SendHeartbeat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointHeartbeat {
+			t.Errorf("expected %s, got %s", endpointHeartbeat, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		PlatformURL: server.URL,
+		APIKey:      "test-api-key",
+		Logger:      logr.Discard(),
+	})
+
+	payload := &HeartbeatPayload{
+		ClusterName: "test-cluster",
+		ClusterUID:  "test-uid",
+		Timestamp:   time.Now(),
+		ResourceCounts: ResourceCounts{
+			Namespaces: 10,
+			Pods:       100,
+			Services:   20,
+		},
+	}
+
+	err := client.SendHeartbeat(context.Background(), payload)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_RetryOnServerError(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			// Return server error for first 2 attempts
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+			return
+		}
+		// Success on 3rd attempt
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		PlatformURL: server.URL,
+		APIKey:      "test-api-key",
+		Timeout:     5 * time.Second,
+		Logger:      logr.Discard(),
+	})
+
+	payload := &HeartbeatPayload{
+		ClusterName: "test-cluster",
+		ClusterUID:  "test-uid",
+		Timestamp:   time.Now(),
+	}
+
+	err := client.SendHeartbeat(context.Background(), payload)
+	if err != nil {
+		t.Errorf("unexpected error after retry: %v", err)
+	}
+
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestClient_NoRetryOnClientError(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request"))
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		PlatformURL: server.URL,
+		APIKey:      "test-api-key",
+		Logger:      logr.Discard(),
+	})
+
+	payload := &HeartbeatPayload{
+		ClusterName: "test-cluster",
+		ClusterUID:  "test-uid",
+		Timestamp:   time.Now(),
+	}
+
+	err := client.SendHeartbeat(context.Background(), payload)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+
+	// Should not retry on client errors
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (no retry), got %d", attempts)
+	}
+}
+
+func TestClient_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate slow server
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		PlatformURL: server.URL,
+		APIKey:      "test-api-key",
+		Logger:      logr.Discard(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	payload := &HeartbeatPayload{
+		ClusterName: "test-cluster",
+		ClusterUID:  "test-uid",
+		Timestamp:   time.Now(),
+	}
+
+	err := client.SendHeartbeat(ctx, payload)
+	if err == nil {
+		t.Error("expected context deadline exceeded error")
+	}
+}
+
+func TestClient_UpdateAPIKey(t *testing.T) {
+	var receivedKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedKey = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		PlatformURL: server.URL,
+		APIKey:      "old-key",
+		Logger:      logr.Discard(),
+	})
+
+	payload := &HeartbeatPayload{
+		ClusterName: "test-cluster",
+		ClusterUID:  "test-uid",
+		Timestamp:   time.Now(),
+	}
+
+	// First request with old key
+	client.SendHeartbeat(context.Background(), payload)
+	if receivedKey != "Bearer old-key" {
+		t.Errorf("expected old key, got %s", receivedKey)
+	}
+
+	// Update key and send again
+	client.UpdateAPIKey("new-key")
+	client.SendHeartbeat(context.Background(), payload)
+	if receivedKey != "Bearer new-key" {
+		t.Errorf("expected new key, got %s", receivedKey)
+	}
+}

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -1,0 +1,245 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package transport
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EventType represents the type of resource change.
+type EventType string
+
+const (
+	EventTypeAdded   EventType = "ADDED"
+	EventTypeUpdated EventType = "UPDATED"
+	EventTypeDeleted EventType = "DELETED"
+)
+
+// ResourceType represents the type of Kubernetes resource.
+type ResourceType string
+
+const (
+	ResourceTypePod       ResourceType = "Pod"
+	ResourceTypeService   ResourceType = "Service"
+	ResourceTypeNamespace ResourceType = "Namespace"
+)
+
+// SnapshotPayload represents a full cluster state snapshot.
+type SnapshotPayload struct {
+	// ClusterName is the human-friendly cluster identifier.
+	ClusterName string `json:"clusterName"`
+
+	// ClusterUID is the unique cluster identifier (kube-system namespace UID).
+	ClusterUID string `json:"clusterUID"`
+
+	// Timestamp when the snapshot was taken.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Namespaces in the cluster.
+	Namespaces []NamespaceInfo `json:"namespaces"`
+
+	// Pods in the cluster.
+	Pods []PodInfo `json:"pods"`
+
+	// Services in the cluster.
+	Services []ServiceInfo `json:"services"`
+}
+
+// EventPayload represents a single resource change event.
+type EventPayload struct {
+	// ClusterName is the human-friendly cluster identifier.
+	ClusterName string `json:"clusterName"`
+
+	// ClusterUID is the unique cluster identifier.
+	ClusterUID string `json:"clusterUID"`
+
+	// Timestamp when the event occurred.
+	Timestamp time.Time `json:"timestamp"`
+
+	// EventType indicates the type of change (ADDED, UPDATED, DELETED).
+	EventType EventType `json:"eventType"`
+
+	// ResourceType indicates what kind of resource changed.
+	ResourceType ResourceType `json:"resourceType"`
+
+	// Resource contains the resource data (one of Namespace, Pod, Service).
+	Resource interface{} `json:"resource"`
+}
+
+// HeartbeatPayload represents a periodic health check.
+type HeartbeatPayload struct {
+	// ClusterName is the human-friendly cluster identifier.
+	ClusterName string `json:"clusterName"`
+
+	// ClusterUID is the unique cluster identifier.
+	ClusterUID string `json:"clusterUID"`
+
+	// Timestamp when the heartbeat was sent.
+	Timestamp time.Time `json:"timestamp"`
+
+	// ResourceCounts contains counts of watched resources.
+	ResourceCounts ResourceCounts `json:"resourceCounts"`
+
+	// Version of the operator.
+	Version string `json:"version,omitempty"`
+}
+
+// ResourceCounts holds counts of watched resources.
+type ResourceCounts struct {
+	Namespaces int32 `json:"namespaces"`
+	Pods       int32 `json:"pods"`
+	Services   int32 `json:"services"`
+}
+
+// NamespaceInfo contains relevant namespace information.
+type NamespaceInfo struct {
+	Name              string            `json:"name"`
+	UID               string            `json:"uid"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	Phase             string            `json:"phase"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+}
+
+// PodInfo contains relevant pod information.
+type PodInfo struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	UID               string            `json:"uid"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	Phase             string            `json:"phase"`
+	NodeName          string            `json:"nodeName,omitempty"`
+	ServiceAccount    string            `json:"serviceAccount,omitempty"`
+	Containers        []ContainerInfo   `json:"containers,omitempty"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+}
+
+// ContainerInfo contains relevant container information.
+type ContainerInfo struct {
+	Name  string `json:"name"`
+	Image string `json:"image"`
+}
+
+// ServiceInfo contains relevant service information.
+type ServiceInfo struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	UID               string            `json:"uid"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	Type              string            `json:"type"`
+	ClusterIP         string            `json:"clusterIP,omitempty"`
+	Ports             []PortInfo        `json:"ports,omitempty"`
+	Selector          map[string]string `json:"selector,omitempty"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+}
+
+// PortInfo contains service port information.
+type PortInfo struct {
+	Name       string `json:"name,omitempty"`
+	Protocol   string `json:"protocol"`
+	Port       int32  `json:"port"`
+	TargetPort string `json:"targetPort,omitempty"`
+}
+
+// NewNamespaceInfo creates NamespaceInfo from a Kubernetes Namespace.
+func NewNamespaceInfo(ns *corev1.Namespace) NamespaceInfo {
+	return NamespaceInfo{
+		Name:              ns.Name,
+		UID:               string(ns.UID),
+		Labels:            ns.Labels,
+		Annotations:       filterAnnotations(ns.Annotations),
+		Phase:             string(ns.Status.Phase),
+		CreationTimestamp: ns.CreationTimestamp.Time,
+	}
+}
+
+// NewPodInfo creates PodInfo from a Kubernetes Pod.
+func NewPodInfo(pod *corev1.Pod) PodInfo {
+	containers := make([]ContainerInfo, 0, len(pod.Spec.Containers))
+	for _, c := range pod.Spec.Containers {
+		containers = append(containers, ContainerInfo{
+			Name:  c.Name,
+			Image: c.Image,
+		})
+	}
+
+	return PodInfo{
+		Name:              pod.Name,
+		Namespace:         pod.Namespace,
+		UID:               string(pod.UID),
+		Labels:            pod.Labels,
+		Annotations:       filterAnnotations(pod.Annotations),
+		Phase:             string(pod.Status.Phase),
+		NodeName:          pod.Spec.NodeName,
+		ServiceAccount:    pod.Spec.ServiceAccountName,
+		Containers:        containers,
+		CreationTimestamp: pod.CreationTimestamp.Time,
+	}
+}
+
+// NewServiceInfo creates ServiceInfo from a Kubernetes Service.
+func NewServiceInfo(svc *corev1.Service) ServiceInfo {
+	ports := make([]PortInfo, 0, len(svc.Spec.Ports))
+	for _, p := range svc.Spec.Ports {
+		ports = append(ports, PortInfo{
+			Name:       p.Name,
+			Protocol:   string(p.Protocol),
+			Port:       p.Port,
+			TargetPort: p.TargetPort.String(),
+		})
+	}
+
+	return ServiceInfo{
+		Name:              svc.Name,
+		Namespace:         svc.Namespace,
+		UID:               string(svc.UID),
+		Labels:            svc.Labels,
+		Annotations:       filterAnnotations(svc.Annotations),
+		Type:              string(svc.Spec.Type),
+		ClusterIP:         svc.Spec.ClusterIP,
+		Ports:             ports,
+		Selector:          svc.Spec.Selector,
+		CreationTimestamp: svc.CreationTimestamp.Time,
+	}
+}
+
+// filterAnnotations removes potentially sensitive or noisy annotations.
+func filterAnnotations(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		return nil
+	}
+
+	// List of annotation prefixes to exclude
+	excludePrefixes := []string{
+		"kubectl.kubernetes.io/",
+		"kubernetes.io/",
+	}
+
+	filtered := make(map[string]string)
+	for k, v := range annotations {
+		exclude := false
+		for _, prefix := range excludePrefixes {
+			if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+				exclude = true
+				break
+			}
+		}
+		if !exclude {
+			filtered[k] = v
+		}
+	}
+
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
+// Ensure metav1 is used for time handling compatibility.
+var _ = metav1.Time{}


### PR DESCRIPTION
## Summary

Implements the HTTP transport client for communicating with the Obsyk platform.

## Changes

- Add `internal/transport/types.go` - Payload types for Snapshot, Event, Heartbeat
- Add `internal/transport/client.go` - HTTP client with retry logic
- Add `internal/transport/client_test.go` - Comprehensive test suite

## Features

### Endpoints
| Method | Endpoint | Purpose |
|--------|----------|---------|
| POST | `/api/v1/agents/snapshot` | Full cluster state |
| POST | `/api/v1/agents/events` | Resource changes |
| POST | `/api/v1/agents/heartbeat` | Health check |

### Error Handling
- **5xx Server errors**: Exponential backoff with jitter (max 5 retries)
- **4xx Client errors**: No retry, immediate failure
- **Context cancellation**: Respected during retries

### Security
- API key passed via `Authorization: Bearer` header
- `UpdateAPIKey()` method for refreshing from Secret

## Test Coverage

60.8% coverage with tests for:
- Successful requests (200, 201)
- Client errors (400, 401) - no retry
- Server errors (500) - retry with backoff
- Context cancellation
- API key updates

## Test plan

- [x] `earthly +ci` passes
- [x] All tests pass
- [ ] Integration test with mock platform (future)

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)