### PR TITLE
[GH-17] Implement OAuth2 JWT Bearer authentication in operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.23
 
 require (
 	github.com/go-logr/logr v1.4.1
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/uuid v1.3.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
@@ -27,7 +29,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,0 +1,276 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const (
+	// grantType is the OAuth2 grant type for JWT Bearer assertions
+	grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+	// tokenEndpoint is the OAuth2 token endpoint path
+	tokenEndpoint = "/oauth/token"
+
+	// assertionTTL is how long the JWT assertion is valid for
+	assertionTTL = 5 * time.Minute
+
+	// tokenRefreshBuffer is how long before expiry to refresh the token
+	tokenRefreshBuffer = 5 * time.Minute
+)
+
+// Credentials holds the OAuth2 client credentials
+type Credentials struct {
+	// ClientID is the OAuth2 client ID issued by the platform
+	ClientID string
+
+	// PrivateKey is the ECDSA P-256 private key for signing assertions
+	PrivateKey *ecdsa.PrivateKey
+}
+
+// ParseCredentials parses credentials from a Secret's data
+// Expected keys: "client_id" and "private_key"
+func ParseCredentials(data map[string][]byte) (*Credentials, error) {
+	clientIDBytes, ok := data["client_id"]
+	if !ok {
+		return nil, fmt.Errorf("secret missing 'client_id' key")
+	}
+	clientID := strings.TrimSpace(string(clientIDBytes))
+	if clientID == "" {
+		return nil, fmt.Errorf("client_id is empty")
+	}
+
+	privateKeyBytes, ok := data["private_key"]
+	if !ok {
+		return nil, fmt.Errorf("secret missing 'private_key' key")
+	}
+
+	privateKey, err := parseECDSAPrivateKey(string(privateKeyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+
+	return &Credentials{
+		ClientID:   clientID,
+		PrivateKey: privateKey,
+	}, nil
+}
+
+// parseECDSAPrivateKey parses a PEM-encoded ECDSA private key
+func parseECDSAPrivateKey(pemData string) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block")
+	}
+
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		// Try PKCS8 format
+		pkcs8Key, err2 := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to parse private key: %w (also tried PKCS8: %w)", err, err2)
+		}
+		ecdsaKey, ok := pkcs8Key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("not an ECDSA private key")
+		}
+		return ecdsaKey, nil
+	}
+
+	return key, nil
+}
+
+// TokenResponse represents the OAuth2 token response
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+// TokenManager manages OAuth2 access tokens with automatic refresh
+type TokenManager struct {
+	platformURL string
+	credentials *Credentials
+	httpClient  *http.Client
+	log         logr.Logger
+
+	mu          sync.RWMutex
+	accessToken string
+	expiresAt   time.Time
+	refreshing  bool
+	refreshCh   chan struct{}
+}
+
+// NewTokenManager creates a new token manager
+func NewTokenManager(platformURL string, credentials *Credentials, httpClient *http.Client, log logr.Logger) *TokenManager {
+	return &TokenManager{
+		platformURL: platformURL,
+		credentials: credentials,
+		httpClient:  httpClient,
+		log:         log,
+	}
+}
+
+// UpdateCredentials updates the credentials used for authentication
+func (tm *TokenManager) UpdateCredentials(credentials *Credentials) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.credentials = credentials
+	// Invalidate current token to force refresh
+	tm.accessToken = ""
+	tm.expiresAt = time.Time{}
+}
+
+// GetAccessToken returns a valid access token, refreshing if necessary
+func (tm *TokenManager) GetAccessToken(ctx context.Context) (string, error) {
+	// Fast path: check if we have a valid token
+	tm.mu.RLock()
+	if tm.accessToken != "" && time.Now().Add(tokenRefreshBuffer).Before(tm.expiresAt) {
+		token := tm.accessToken
+		tm.mu.RUnlock()
+		return token, nil
+	}
+	tm.mu.RUnlock()
+
+	// Slow path: need to refresh
+	return tm.refreshToken(ctx)
+}
+
+// refreshToken obtains a new access token from the platform
+func (tm *TokenManager) refreshToken(ctx context.Context) (string, error) {
+	tm.mu.Lock()
+
+	// Check again in case another goroutine already refreshed
+	if tm.accessToken != "" && time.Now().Add(tokenRefreshBuffer).Before(tm.expiresAt) {
+		token := tm.accessToken
+		tm.mu.Unlock()
+		return token, nil
+	}
+
+	// If already refreshing, wait for it
+	if tm.refreshing {
+		ch := tm.refreshCh
+		tm.mu.Unlock()
+		<-ch
+		return tm.GetAccessToken(ctx)
+	}
+
+	// Mark as refreshing
+	tm.refreshing = true
+	tm.refreshCh = make(chan struct{})
+	creds := tm.credentials
+	tm.mu.Unlock()
+
+	// Create JWT assertion
+	assertion, err := tm.createAssertion(creds)
+	if err != nil {
+		tm.finishRefresh("", time.Time{})
+		return "", fmt.Errorf("creating assertion: %w", err)
+	}
+
+	// Exchange assertion for access token
+	tokenResp, err := tm.exchangeAssertion(ctx, assertion)
+	if err != nil {
+		tm.finishRefresh("", time.Time{})
+		return "", fmt.Errorf("exchanging assertion: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	tm.finishRefresh(tokenResp.AccessToken, expiresAt)
+
+	tm.log.Info("obtained access token",
+		"expires_in", tokenResp.ExpiresIn,
+		"expires_at", expiresAt.Format(time.RFC3339))
+
+	return tokenResp.AccessToken, nil
+}
+
+// finishRefresh updates the token state and signals waiting goroutines
+func (tm *TokenManager) finishRefresh(token string, expiresAt time.Time) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	tm.accessToken = token
+	tm.expiresAt = expiresAt
+	tm.refreshing = false
+	if tm.refreshCh != nil {
+		close(tm.refreshCh)
+		tm.refreshCh = nil
+	}
+}
+
+// createAssertion creates a signed JWT Bearer assertion
+func (tm *TokenManager) createAssertion(creds *Credentials) (string, error) {
+	now := time.Now()
+
+	claims := jwt.RegisteredClaims{
+		ID:        uuid.New().String(),
+		Issuer:    creds.ClientID,
+		Subject:   creds.ClientID,
+		Audience:  jwt.ClaimStrings{tm.platformURL},
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(assertionTTL)),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	return token.SignedString(creds.PrivateKey)
+}
+
+// exchangeAssertion exchanges a JWT assertion for an access token
+func (tm *TokenManager) exchangeAssertion(ctx context.Context, assertion string) (*TokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", grantType)
+	form.Set("assertion", assertion)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tm.platformURL+tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "obsyk-operator/1.0")
+
+	resp, err := tm.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("empty access token in response")
+	}
+
+	return &tokenResp, nil
+}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,0 +1,338 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// generateTestKeyPair generates a test ECDSA P-256 key pair
+func generateTestKeyPair(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	// Encode private key to PEM
+	keyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to marshal private key: %v", err)
+	}
+
+	pemBlock := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+
+	return privateKey, string(pemBlock)
+}
+
+func TestParseCredentials(t *testing.T) {
+	_, privatePEM := generateTestKeyPair(t)
+
+	tests := []struct {
+		name    string
+		data    map[string][]byte
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid credentials",
+			data: map[string][]byte{
+				"client_id":   []byte("test-client-id"),
+				"private_key": []byte(privatePEM),
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing client_id",
+			data: map[string][]byte{
+				"private_key": []byte(privatePEM),
+			},
+			wantErr: true,
+			errMsg:  "missing 'client_id'",
+		},
+		{
+			name: "missing private_key",
+			data: map[string][]byte{
+				"client_id": []byte("test-client-id"),
+			},
+			wantErr: true,
+			errMsg:  "missing 'private_key'",
+		},
+		{
+			name: "empty client_id",
+			data: map[string][]byte{
+				"client_id":   []byte("  "),
+				"private_key": []byte(privatePEM),
+			},
+			wantErr: true,
+			errMsg:  "client_id is empty",
+		},
+		{
+			name: "invalid private_key",
+			data: map[string][]byte{
+				"client_id":   []byte("test-client-id"),
+				"private_key": []byte("invalid-key"),
+			},
+			wantErr: true,
+			errMsg:  "failed to parse PEM block",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := ParseCredentials(tt.data)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Error %q should contain %q", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if creds == nil {
+					t.Error("Expected credentials but got nil")
+				} else if creds.ClientID != "test-client-id" {
+					t.Errorf("ClientID = %q, want %q", creds.ClientID, "test-client-id")
+				}
+			}
+		})
+	}
+}
+
+func TestTokenManager_CreateAssertion(t *testing.T) {
+	privateKey, privatePEM := generateTestKeyPair(t)
+
+	creds, err := ParseCredentials(map[string][]byte{
+		"client_id":   []byte("test-client-id"),
+		"private_key": []byte(privatePEM),
+	})
+	if err != nil {
+		t.Fatalf("Failed to parse credentials: %v", err)
+	}
+
+	tm := NewTokenManager("https://api.example.com", creds, http.DefaultClient, logr.Discard())
+
+	assertion, err := tm.createAssertion(creds)
+	if err != nil {
+		t.Fatalf("Failed to create assertion: %v", err)
+	}
+
+	// Verify the assertion can be parsed and validated
+	token, err := jwt.ParseWithClaims(assertion, &jwt.RegisteredClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return &privateKey.PublicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to parse assertion: %v", err)
+	}
+
+	if !token.Valid {
+		t.Error("Token is not valid")
+	}
+
+	claims, ok := token.Claims.(*jwt.RegisteredClaims)
+	if !ok {
+		t.Fatal("Failed to get claims")
+	}
+
+	if claims.Issuer != "test-client-id" {
+		t.Errorf("Issuer = %q, want %q", claims.Issuer, "test-client-id")
+	}
+
+	if claims.Subject != "test-client-id" {
+		t.Errorf("Subject = %q, want %q", claims.Subject, "test-client-id")
+	}
+
+	if claims.ExpiresAt == nil {
+		t.Error("ExpiresAt is nil")
+	} else if claims.ExpiresAt.Before(time.Now()) {
+		t.Error("Token is already expired")
+	}
+}
+
+func TestTokenManager_GetAccessToken(t *testing.T) {
+	_, privatePEM := generateTestKeyPair(t)
+
+	// Create a mock token server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("Unexpected path: %s", r.URL.Path)
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			t.Errorf("Unexpected method: %s", r.Method)
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/x-www-form-urlencoded" {
+			t.Errorf("Unexpected Content-Type: %s", contentType)
+		}
+
+		err := r.ParseForm()
+		if err != nil {
+			t.Errorf("Failed to parse form: %v", err)
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		grantType := r.FormValue("grant_type")
+		if grantType != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+			t.Errorf("Unexpected grant_type: %s", grantType)
+		}
+
+		assertion := r.FormValue("assertion")
+		if assertion == "" {
+			t.Error("Missing assertion")
+			http.Error(w, "Missing assertion", http.StatusBadRequest)
+			return
+		}
+
+		// Return a mock token
+		resp := TokenResponse{
+			AccessToken: "mock-access-token-12345",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	creds, err := ParseCredentials(map[string][]byte{
+		"client_id":   []byte("test-client-id"),
+		"private_key": []byte(privatePEM),
+	})
+	if err != nil {
+		t.Fatalf("Failed to parse credentials: %v", err)
+	}
+
+	tm := NewTokenManager(server.URL, creds, server.Client(), logr.Discard())
+
+	// Get access token
+	token, err := tm.GetAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get access token: %v", err)
+	}
+
+	if token != "mock-access-token-12345" {
+		t.Errorf("Token = %q, want %q", token, "mock-access-token-12345")
+	}
+
+	// Second call should return cached token
+	token2, err := tm.GetAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get cached access token: %v", err)
+	}
+
+	if token2 != token {
+		t.Errorf("Cached token = %q, want %q", token2, token)
+	}
+}
+
+func TestTokenManager_TokenRefresh(t *testing.T) {
+	_, privatePEM := generateTestKeyPair(t)
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := TokenResponse{
+			AccessToken: "token-" + string(rune('A'+callCount-1)),
+			TokenType:   "Bearer",
+			ExpiresIn:   1, // 1 second expiry
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	creds, _ := ParseCredentials(map[string][]byte{
+		"client_id":   []byte("test-client-id"),
+		"private_key": []byte(privatePEM),
+	})
+
+	tm := NewTokenManager(server.URL, creds, server.Client(), logr.Discard())
+
+	// First call
+	token1, _ := tm.GetAccessToken(context.Background())
+
+	// Wait for token to expire (plus buffer)
+	time.Sleep(2 * time.Second)
+
+	// Second call should refresh
+	token2, _ := tm.GetAccessToken(context.Background())
+
+	if token1 == token2 {
+		t.Error("Expected different tokens after refresh")
+	}
+
+	if callCount < 2 {
+		t.Errorf("Expected at least 2 token requests, got %d", callCount)
+	}
+}
+
+func TestTokenManager_UpdateCredentials(t *testing.T) {
+	_, privatePEM1 := generateTestKeyPair(t)
+	_, privatePEM2 := generateTestKeyPair(t)
+
+	tokenIndex := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenIndex++
+		resp := TokenResponse{
+			AccessToken: "token-" + string(rune('0'+tokenIndex)),
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	creds1, _ := ParseCredentials(map[string][]byte{
+		"client_id":   []byte("client-1"),
+		"private_key": []byte(privatePEM1),
+	})
+
+	creds2, _ := ParseCredentials(map[string][]byte{
+		"client_id":   []byte("client-2"),
+		"private_key": []byte(privatePEM2),
+	})
+
+	tm := NewTokenManager(server.URL, creds1, server.Client(), logr.Discard())
+
+	// Get token with first credentials
+	token1, _ := tm.GetAccessToken(context.Background())
+
+	// Update credentials
+	tm.UpdateCredentials(creds2)
+
+	// Get token with new credentials (should refresh)
+	token2, _ := tm.GetAccessToken(context.Background())
+
+	if token1 == token2 {
+		t.Error("Expected different token after credentials update")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement OAuth2 JWT Bearer authentication (RFC 7523) for secure agent-to-platform communication
- Add `auth` package with `TokenManager` for JWT signing and automatic token refresh
- Update transport client to use `TokenProvider` interface
- Update controller to parse OAuth2 credentials from Kubernetes Secret

## Breaking Change: Secret Format

The agent secret format has changed from:

```yaml
data:
  token: <api-key>
```

To:

```yaml
data:
  client_id: <oauth2-client-id>
  private_key: <pem-encoded-ecdsa-p256-private-key>
```

## Authentication Flow

1. Agent reads `client_id` and `private_key` from Secret
2. Creates JWT assertion signed with private key
3. Exchanges assertion for access token via `/oauth/token`
4. Uses access token for all API calls
5. Automatically refreshes token before expiry (tokens last 1 hour)

## Test plan

- [x] Unit tests for auth package (JWT signing, token refresh)
- [x] Unit tests for transport client with TokenProvider
- [ ] Integration test with real platform (manual testing required)

fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)