### PR TITLE
fix: align JSON field names with platform API and update metrics config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	obsykv1 "github.com/obsyk/obsyk-operator/api/v1"
 	"github.com/obsyk/obsyk-operator/internal/controller"
@@ -48,7 +49,10 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsAddr,
+		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "obsyk-operator.obsyk.io",

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -93,9 +93,9 @@ func TestClient_SendSnapshot(t *testing.T) {
 			})
 
 			payload := &SnapshotPayload{
-				ClusterName: "test-cluster",
-				ClusterUID:  "test-uid",
-				Timestamp:   time.Now(),
+				ClusterUID:   "test-uid",
+				ClusterName:  "test-cluster",
+				AgentVersion: "0.1.0",
 			}
 
 			err := client.SendSnapshot(context.Background(), payload)
@@ -134,8 +134,8 @@ func TestClient_SendEvent(t *testing.T) {
 			t.Errorf("failed to decode payload: %v", err)
 		}
 
-		if payload.EventType != EventTypeAdded {
-			t.Errorf("expected event type ADDED, got %s", payload.EventType)
+		if payload.Type != "added" {
+			t.Errorf("expected event type added, got %s", payload.Type)
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -149,12 +149,13 @@ func TestClient_SendEvent(t *testing.T) {
 	})
 
 	payload := &EventPayload{
-		ClusterName:  "test-cluster",
-		ClusterUID:   "test-uid",
-		Timestamp:    time.Now(),
-		EventType:    EventTypeAdded,
-		ResourceType: ResourceTypePod,
-		Resource:     map[string]string{"name": "test-pod"},
+		ClusterUID: "test-uid",
+		Type:       "added",
+		Kind:       "Pod",
+		UID:        "pod-uid-123",
+		Name:       "test-pod",
+		Namespace:  "default",
+		Object:     map[string]string{"name": "test-pod"},
 	}
 
 	err := client.SendEvent(context.Background(), payload)
@@ -179,14 +180,8 @@ func TestClient_SendHeartbeat(t *testing.T) {
 	})
 
 	payload := &HeartbeatPayload{
-		ClusterName: "test-cluster",
-		ClusterUID:  "test-uid",
-		Timestamp:   time.Now(),
-		ResourceCounts: ResourceCounts{
-			Namespaces: 10,
-			Pods:       100,
-			Services:   20,
-		},
+		ClusterUID:   "test-uid",
+		AgentVersion: "0.1.0",
 	}
 
 	err := client.SendHeartbeat(context.Background(), payload)
@@ -219,9 +214,8 @@ func TestClient_RetryOnServerError(t *testing.T) {
 	})
 
 	payload := &HeartbeatPayload{
-		ClusterName: "test-cluster",
-		ClusterUID:  "test-uid",
-		Timestamp:   time.Now(),
+		ClusterUID:   "test-uid",
+		AgentVersion: "0.1.0",
 	}
 
 	err := client.SendHeartbeat(context.Background(), payload)
@@ -251,9 +245,8 @@ func TestClient_NoRetryOnClientError(t *testing.T) {
 	})
 
 	payload := &HeartbeatPayload{
-		ClusterName: "test-cluster",
-		ClusterUID:  "test-uid",
-		Timestamp:   time.Now(),
+		ClusterUID:   "test-uid",
+		AgentVersion: "0.1.0",
 	}
 
 	err := client.SendHeartbeat(context.Background(), payload)
@@ -285,9 +278,8 @@ func TestClient_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	payload := &HeartbeatPayload{
-		ClusterName: "test-cluster",
-		ClusterUID:  "test-uid",
-		Timestamp:   time.Now(),
+		ClusterUID:   "test-uid",
+		AgentVersion: "0.1.0",
 	}
 
 	err := client.SendHeartbeat(ctx, payload)
@@ -312,9 +304,8 @@ func TestClient_UpdateTokenProvider(t *testing.T) {
 	})
 
 	payload := &HeartbeatPayload{
-		ClusterName: "test-cluster",
-		ClusterUID:  "test-uid",
-		Timestamp:   time.Now(),
+		ClusterUID:   "test-uid",
+		AgentVersion: "0.1.0",
 	}
 
 	// First request with old token

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -30,14 +30,23 @@ const (
 
 // SnapshotPayload represents a full cluster state snapshot.
 type SnapshotPayload struct {
-	// ClusterName is the human-friendly cluster identifier.
-	ClusterName string `json:"clusterName"`
-
 	// ClusterUID is the unique cluster identifier (kube-system namespace UID).
-	ClusterUID string `json:"clusterUID"`
+	ClusterUID string `json:"cluster_uid"`
 
-	// Timestamp when the snapshot was taken.
-	Timestamp time.Time `json:"timestamp"`
+	// ClusterName is the human-friendly cluster identifier.
+	ClusterName string `json:"cluster_name"`
+
+	// KubernetesVersion is the cluster's K8s version.
+	KubernetesVersion string `json:"kubernetes_version,omitempty"`
+
+	// Platform is the cluster platform (e.g., eks, gke, kind).
+	Platform string `json:"platform,omitempty"`
+
+	// Region is the cluster region.
+	Region string `json:"region,omitempty"`
+
+	// AgentVersion is the operator version.
+	AgentVersion string `json:"agent_version,omitempty"`
 
 	// Namespaces in the cluster.
 	Namespaces []NamespaceInfo `json:"namespaces"`
@@ -51,41 +60,35 @@ type SnapshotPayload struct {
 
 // EventPayload represents a single resource change event.
 type EventPayload struct {
-	// ClusterName is the human-friendly cluster identifier.
-	ClusterName string `json:"clusterName"`
-
 	// ClusterUID is the unique cluster identifier.
-	ClusterUID string `json:"clusterUID"`
+	ClusterUID string `json:"cluster_uid"`
 
-	// Timestamp when the event occurred.
-	Timestamp time.Time `json:"timestamp"`
+	// EventType indicates the type of change (added, modified, deleted).
+	Type string `json:"type"`
 
-	// EventType indicates the type of change (ADDED, UPDATED, DELETED).
-	EventType EventType `json:"eventType"`
+	// Kind indicates what kind of resource changed (Namespace, Pod, Service).
+	Kind string `json:"kind"`
 
-	// ResourceType indicates what kind of resource changed.
-	ResourceType ResourceType `json:"resourceType"`
+	// UID is the resource's unique identifier.
+	UID string `json:"uid"`
 
-	// Resource contains the resource data (one of Namespace, Pod, Service).
-	Resource interface{} `json:"resource"`
+	// Name is the resource name.
+	Name string `json:"name"`
+
+	// Namespace is the resource namespace (empty for cluster-scoped resources).
+	Namespace string `json:"namespace,omitempty"`
+
+	// Object contains the full resource data for add/update, nil for delete.
+	Object interface{} `json:"object,omitempty"`
 }
 
 // HeartbeatPayload represents a periodic health check.
 type HeartbeatPayload struct {
-	// ClusterName is the human-friendly cluster identifier.
-	ClusterName string `json:"clusterName"`
-
 	// ClusterUID is the unique cluster identifier.
-	ClusterUID string `json:"clusterUID"`
+	ClusterUID string `json:"cluster_uid"`
 
-	// Timestamp when the heartbeat was sent.
-	Timestamp time.Time `json:"timestamp"`
-
-	// ResourceCounts contains counts of watched resources.
-	ResourceCounts ResourceCounts `json:"resourceCounts"`
-
-	// Version of the operator.
-	Version string `json:"version,omitempty"`
+	// AgentVersion of the operator.
+	AgentVersion string `json:"agent_version,omitempty"`
 }
 
 // ResourceCounts holds counts of watched resources.
@@ -97,26 +100,26 @@ type ResourceCounts struct {
 
 // NamespaceInfo contains relevant namespace information.
 type NamespaceInfo struct {
-	Name              string            `json:"name"`
-	UID               string            `json:"uid"`
-	Labels            map[string]string `json:"labels,omitempty"`
-	Annotations       map[string]string `json:"annotations,omitempty"`
-	Phase             string            `json:"phase"`
-	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	UID          string            `json:"uid"`
+	Name         string            `json:"name"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	Phase        string            `json:"phase,omitempty"`
+	K8sCreatedAt *time.Time        `json:"k8s_created_at,omitempty"`
 }
 
 // PodInfo contains relevant pod information.
 type PodInfo struct {
-	Name              string            `json:"name"`
-	Namespace         string            `json:"namespace"`
-	UID               string            `json:"uid"`
-	Labels            map[string]string `json:"labels,omitempty"`
-	Annotations       map[string]string `json:"annotations,omitempty"`
-	Phase             string            `json:"phase"`
-	NodeName          string            `json:"nodeName,omitempty"`
-	ServiceAccount    string            `json:"serviceAccount,omitempty"`
-	Containers        []ContainerInfo   `json:"containers,omitempty"`
-	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	UID            string            `json:"uid"`
+	Name           string            `json:"name"`
+	Namespace      string            `json:"namespace"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	NodeName       string            `json:"node_name,omitempty"`
+	ServiceAccount string            `json:"service_account,omitempty"`
+	Containers     []ContainerInfo   `json:"containers,omitempty"`
+	Phase          string            `json:"phase,omitempty"`
+	K8sCreatedAt   *time.Time        `json:"k8s_created_at,omitempty"`
 }
 
 // ContainerInfo contains relevant container information.
@@ -127,16 +130,16 @@ type ContainerInfo struct {
 
 // ServiceInfo contains relevant service information.
 type ServiceInfo struct {
-	Name              string            `json:"name"`
-	Namespace         string            `json:"namespace"`
-	UID               string            `json:"uid"`
-	Labels            map[string]string `json:"labels,omitempty"`
-	Annotations       map[string]string `json:"annotations,omitempty"`
-	Type              string            `json:"type"`
-	ClusterIP         string            `json:"clusterIP,omitempty"`
-	Ports             []PortInfo        `json:"ports,omitempty"`
-	Selector          map[string]string `json:"selector,omitempty"`
-	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	UID          string            `json:"uid"`
+	Name         string            `json:"name"`
+	Namespace    string            `json:"namespace"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	ServiceType  string            `json:"service_type,omitempty"`
+	ClusterIP    string            `json:"cluster_ip,omitempty"`
+	Ports        []PortInfo        `json:"ports,omitempty"`
+	Selector     map[string]string `json:"selector,omitempty"`
+	K8sCreatedAt *time.Time        `json:"k8s_created_at,omitempty"`
 }
 
 // PortInfo contains service port information.
@@ -149,13 +152,14 @@ type PortInfo struct {
 
 // NewNamespaceInfo creates NamespaceInfo from a Kubernetes Namespace.
 func NewNamespaceInfo(ns *corev1.Namespace) NamespaceInfo {
+	createdAt := ns.CreationTimestamp.Time
 	return NamespaceInfo{
-		Name:              ns.Name,
-		UID:               string(ns.UID),
-		Labels:            ns.Labels,
-		Annotations:       filterAnnotations(ns.Annotations),
-		Phase:             string(ns.Status.Phase),
-		CreationTimestamp: ns.CreationTimestamp.Time,
+		UID:          string(ns.UID),
+		Name:         ns.Name,
+		Labels:       ns.Labels,
+		Annotations:  filterAnnotations(ns.Annotations),
+		Phase:        string(ns.Status.Phase),
+		K8sCreatedAt: &createdAt,
 	}
 }
 
@@ -169,17 +173,18 @@ func NewPodInfo(pod *corev1.Pod) PodInfo {
 		})
 	}
 
+	createdAt := pod.CreationTimestamp.Time
 	return PodInfo{
-		Name:              pod.Name,
-		Namespace:         pod.Namespace,
-		UID:               string(pod.UID),
-		Labels:            pod.Labels,
-		Annotations:       filterAnnotations(pod.Annotations),
-		Phase:             string(pod.Status.Phase),
-		NodeName:          pod.Spec.NodeName,
-		ServiceAccount:    pod.Spec.ServiceAccountName,
-		Containers:        containers,
-		CreationTimestamp: pod.CreationTimestamp.Time,
+		UID:            string(pod.UID),
+		Name:           pod.Name,
+		Namespace:      pod.Namespace,
+		Labels:         pod.Labels,
+		Annotations:    filterAnnotations(pod.Annotations),
+		NodeName:       pod.Spec.NodeName,
+		ServiceAccount: pod.Spec.ServiceAccountName,
+		Containers:     containers,
+		Phase:          string(pod.Status.Phase),
+		K8sCreatedAt:   &createdAt,
 	}
 }
 
@@ -195,17 +200,18 @@ func NewServiceInfo(svc *corev1.Service) ServiceInfo {
 		})
 	}
 
+	createdAt := svc.CreationTimestamp.Time
 	return ServiceInfo{
-		Name:              svc.Name,
-		Namespace:         svc.Namespace,
-		UID:               string(svc.UID),
-		Labels:            svc.Labels,
-		Annotations:       filterAnnotations(svc.Annotations),
-		Type:              string(svc.Spec.Type),
-		ClusterIP:         svc.Spec.ClusterIP,
-		Ports:             ports,
-		Selector:          svc.Spec.Selector,
-		CreationTimestamp: svc.CreationTimestamp.Time,
+		UID:          string(svc.UID),
+		Name:         svc.Name,
+		Namespace:    svc.Namespace,
+		Labels:       svc.Labels,
+		Annotations:  filterAnnotations(svc.Annotations),
+		ServiceType:  string(svc.Spec.Type),
+		ClusterIP:    svc.Spec.ClusterIP,
+		Ports:        ports,
+		Selector:     svc.Spec.Selector,
+		K8sCreatedAt: &createdAt,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update all transport type JSON tags from camelCase to snake_case to match platform API expectations (e.g., `cluster_uid` instead of `clusterUID`)
- Fix metrics server configuration for controller-runtime v0.17.0 using new `Metrics.Options` struct syntax
- Simplify controller sendSnapshot and sendHeartbeat methods
- Update client tests to match new payload structures

## Changes
- `cmd/main.go`: Use `metricsserver.Options` for metrics configuration
- `internal/transport/types.go`: Update all JSON tags to snake_case
- `internal/controller/obsykagent_controller.go`: Simplify payload construction
- `internal/transport/client_test.go`: Update tests for new struct definitions

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] E2E tested: operator successfully syncs cluster data to platform (6 namespaces, 9 pods, 2 services)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)