### PR TITLE
[GH-23] chore: migrate domain from obsyk.com to obsyk.ai

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ metadata:
   namespace: obsyk-system
 spec:
   # Platform endpoint (Obsyk SaaS)
-  platformURL: "https://api.obsyk.com"
+  platformURL: "https://api.obsyk.ai"
 
   # Logical cluster identifier
   clusterName: "production-us-east-1"
@@ -349,7 +349,7 @@ The operator uses OAuth2 JWT Bearer Assertion (RFC 7523) for authentication:
 {
   "iss": "<client_id>",
   "sub": "<client_id>",
-  "aud": ["https://api.obsyk.com"],
+  "aud": ["https://api.obsyk.ai"],
   "iat": 1705312200,
   "exp": 1705312500,
   "jti": "<unique-id>"
@@ -358,7 +358,7 @@ The operator uses OAuth2 JWT Bearer Assertion (RFC 7523) for authentication:
 
 **Token Request:**
 ```bash
-curl -X POST https://api.obsyk.com/oauth/token \
+curl -X POST https://api.obsyk.ai/oauth/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer" \
   -d "assertion=<signed-jwt>"
@@ -366,7 +366,7 @@ curl -X POST https://api.obsyk.com/oauth/token \
 
 **API Request:**
 ```bash
-curl -X POST https://api.obsyk.com/api/v1/agent/snapshot \
+curl -X POST https://api.obsyk.ai/api/v1/agent/snapshot \
   -H "Authorization: Bearer <access-token>" \
   -H "Content-Type: application/json" \
   -d '{"cluster_uid": "...", ...}'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsyk Operator
 
-Kubernetes operator that connects your cluster to the [Obsyk](https://obsyk.com) observability platform. Deploy once and automatically stream cluster metadata to gain visibility across your infrastructure.
+Kubernetes operator that connects your cluster to the [Obsyk](https://obsyk.ai) observability platform. Deploy once and automatically stream cluster metadata to gain visibility across your infrastructure.
 
 ## Features
 
@@ -40,7 +40,7 @@ kubectl create secret generic obsyk-api-key \
 helm install obsyk-operator obsyk/obsyk-operator \
   --namespace obsyk-system \
   --set agent.clusterName="my-cluster" \
-  --set agent.platformURL="https://api.obsyk.com"
+  --set agent.platformURL="https://api.obsyk.ai"
 ```
 
 ## Configuration
@@ -50,7 +50,7 @@ helm install obsyk-operator obsyk/obsyk-operator \
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `agent.clusterName` | Logical name for this cluster | `""` (required) |
-| `agent.platformURL` | Obsyk platform endpoint | `https://api.obsyk.com` |
+| `agent.platformURL` | Obsyk platform endpoint | `https://api.obsyk.ai` |
 | `agent.apiKeySecretRef.name` | Secret containing API key | `obsyk-api-key` |
 | `agent.apiKeySecretRef.key` | Key within the Secret | `token` |
 | `replicaCount` | Number of operator replicas | `1` |
@@ -70,7 +70,7 @@ metadata:
   name: obsyk-agent
   namespace: obsyk-system
 spec:
-  platformURL: "https://api.obsyk.com"
+  platformURL: "https://api.obsyk.ai"
   clusterName: "production-us-east-1"
   apiKeySecretRef:
     name: obsyk-api-key
@@ -155,6 +155,6 @@ Apache License 2.0 - see [LICENSE](./LICENSE) for details.
 
 ## Support
 
-- Documentation: [docs.obsyk.com](https://docs.obsyk.com)
+- Documentation: [docs.obsyk.ai](https://docs.obsyk.ai)
 - Issues: [GitHub Issues](https://github.com/Obsyk/obsyk-operator/issues)
 - Email: support@obsyk.com

--- a/charts/obsyk-operator/Chart.yaml
+++ b/charts/obsyk-operator/Chart.yaml
@@ -5,13 +5,13 @@ type: application
 version: 0.1.0
 appVersion: "0.1.0"
 kubeVersion: ">=1.26.0-0"
-home: https://obsyk.com
+home: https://obsyk.ai
 sources:
   - https://github.com/Obsyk/obsyk-operator
 maintainers:
   - name: Obsyk
     email: support@obsyk.com
-    url: https://obsyk.com
+    url: https://obsyk.ai
 keywords:
   - observability
   - kubernetes

--- a/charts/obsyk-operator/templates/NOTES.txt
+++ b/charts/obsyk-operator/templates/NOTES.txt
@@ -33,7 +33,7 @@ To create an agent manually:
     name: obsyk-agent
     namespace: {{ .Release.Namespace }}
   spec:
-    platformURL: "https://api.obsyk.com"
+    platformURL: "https://api.obsyk.ai"
     clusterName: "your-cluster-name"
     apiKeySecretRef:
       name: obsyk-api-key
@@ -42,4 +42,4 @@ To create an agent manually:
 
 {{- end }}
 
-For more information, visit: https://docs.obsyk.com
+For more information, visit: https://docs.obsyk.ai

--- a/charts/obsyk-operator/values.yaml
+++ b/charts/obsyk-operator/values.yaml
@@ -22,7 +22,7 @@ agent:
   clusterName: ""
 
   # Obsyk platform URL
-  platformURL: "https://api.obsyk.com"
+  platformURL: "https://api.obsyk.ai"
 
   # API key secret reference
   apiKeySecretRef:


### PR DESCRIPTION
## Summary
- Update all domain references from `obsyk.com` to `obsyk.ai`
- Helm chart platformURL default changed to `https://api.obsyk.ai`
- Chart metadata (home, maintainer URL) updated
- Documentation updated (README.md, CLAUDE.md)

## Files Changed
- `charts/obsyk-operator/values.yaml` - platformURL
- `charts/obsyk-operator/Chart.yaml` - home, maintainer url
- `charts/obsyk-operator/templates/NOTES.txt` - platformURL, docs link
- `README.md` - api endpoint, docs link
- `CLAUDE.md` - platform examples, curl commands

## Test plan
- [ ] Verify Helm chart renders correctly with new defaults
- [ ] Confirm documentation links are valid after obsyk.ai is live

fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)