### PR TITLE
[GH-26] fix: helm chart publishing and update documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,20 @@ jobs:
       - name: Package and index Helm chart
         run: |
           if [ -d "main/charts/obsyk-operator" ]; then
+            # Package the chart
             helm package main/charts/obsyk-operator --destination .
+
+            # Remove the main checkout directory before adding to git
+            rm -rf main
+
+            # Add .nojekyll to prevent Jekyll processing
+            touch .nojekyll
+
+            # Update the helm repo index
             helm repo index . --url https://obsyk.github.io/obsyk-operator
-            git add .
+
+            # Add only the chart files, not everything
+            git add index.yaml .nojekyll "obsyk-operator-*.tgz"
             git commit -m "Release Helm chart ${{ github.ref_name }}"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -6,42 +6,67 @@ Kubernetes operator that connects your cluster to the [Obsyk](https://obsyk.ai) 
 
 - **Deploy & Forget** - Single Custom Resource configures everything
 - **Real-time Sync** - Stream Namespace, Pod, and Service changes as they happen
-- **Secure by Design** - Read-only cluster access, API keys stored in Secrets
+- **Secure by Design** - Read-only cluster access, OAuth2 JWT authentication
 - **Lightweight** - Minimal resource footprint, efficient event-driven architecture
 
 ## Prerequisites
 
 - Kubernetes 1.26+
 - Helm 3.x
-- Obsyk account with API key
+- Obsyk account (sign up at [app.obsyk.ai](https://app.obsyk.ai))
 
 ## Quick Start
 
-### 1. Add the Helm Repository
+### 1. Register Your Cluster in Obsyk
+
+1. Log in to [app.obsyk.ai](https://app.obsyk.ai)
+2. Navigate to **Clusters** and click **Add cluster**
+3. Enter a name for your cluster and click **Generate credentials**
+4. Save the **Client ID** and **Private Key** - you'll need these for installation
+
+### 2. Add the Helm Repository
 
 ```bash
 helm repo add obsyk https://obsyk.github.io/obsyk-operator
 helm repo update
 ```
 
-### 2. Create API Key Secret
+### 3. Create Credentials Secret
+
+Save your private key to a file (e.g., `private-key.pem`), then create the secret:
 
 ```bash
 kubectl create namespace obsyk-system
 
-kubectl create secret generic obsyk-api-key \
+kubectl create secret generic obsyk-credentials \
   --namespace obsyk-system \
-  --from-literal=token=YOUR_API_KEY
+  --from-literal=client_id=YOUR_CLIENT_ID \
+  --from-file=private_key=private-key.pem
 ```
 
-### 3. Install the Operator
+### 4. Install the Operator
 
 ```bash
 helm install obsyk-operator obsyk/obsyk-operator \
   --namespace obsyk-system \
   --set agent.clusterName="my-cluster" \
-  --set agent.platformURL="https://api.obsyk.ai"
+  --set agent.platformURL="https://app.obsyk.ai"
 ```
+
+### 5. Verify Installation
+
+```bash
+# Check the operator is running
+kubectl get pods -n obsyk-system
+
+# Check the agent status
+kubectl get obsykagent -n obsyk-system
+
+# View operator logs
+kubectl logs -n obsyk-system -l app.kubernetes.io/name=obsyk-operator
+```
+
+Your cluster should now appear as **Connected** in the Obsyk dashboard!
 
 ## Configuration
 
@@ -49,10 +74,11 @@ helm install obsyk-operator obsyk/obsyk-operator \
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `agent.clusterName` | Logical name for this cluster | `""` (required) |
+| `agent.enabled` | Create ObsykAgent CR | `true` |
+| `agent.clusterName` | Display name for this cluster | `""` (required) |
 | `agent.platformURL` | Obsyk platform endpoint | `https://api.obsyk.ai` |
-| `agent.apiKeySecretRef.name` | Secret containing API key | `obsyk-api-key` |
-| `agent.apiKeySecretRef.key` | Key within the Secret | `token` |
+| `agent.credentialsSecretRef.name` | Secret containing OAuth2 credentials | `obsyk-credentials` |
+| `agent.syncInterval` | Heartbeat/sync interval | `5m` |
 | `replicaCount` | Number of operator replicas | `1` |
 | `resources.limits.cpu` | CPU limit | `200m` |
 | `resources.limits.memory` | Memory limit | `256Mi` |
@@ -70,14 +96,40 @@ metadata:
   name: obsyk-agent
   namespace: obsyk-system
 spec:
-  platformURL: "https://api.obsyk.ai"
+  platformURL: "https://app.obsyk.ai"
   clusterName: "production-us-east-1"
-  apiKeySecretRef:
-    name: obsyk-api-key
-    key: token
+  credentialsSecretRef:
+    name: obsyk-credentials
+  syncInterval: "5m"
+```
+
+### Credentials Secret Format
+
+The credentials secret must contain:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: obsyk-credentials
+  namespace: obsyk-system
+type: Opaque
+data:
+  client_id: <base64-encoded OAuth2 client ID>
+  private_key: <base64-encoded PEM ECDSA P-256 private key>
 ```
 
 ## Security
+
+### Authentication
+
+The operator uses **OAuth2 JWT Bearer** authentication (RFC 7523):
+
+1. When you register a cluster in Obsyk, an ECDSA P-256 key pair is generated
+2. The public key is stored by Obsyk, private key is given to you
+3. The operator creates JWT assertions signed with the private key
+4. Tokens are exchanged for short-lived access tokens (1 hour TTL)
+5. Access tokens are automatically refreshed before expiry
 
 ### RBAC Permissions
 
@@ -89,11 +141,12 @@ The operator requires **read-only** access to cluster resources:
 | Pods | list, watch |
 | Services | list, watch |
 
-### API Key Security
+### Credential Security
 
-- API keys are **never** stored in the Custom Resource
+- Private keys are **never** stored in the Custom Resource
 - Keys must be provided via Kubernetes Secret reference
 - Keys are read at runtime and never logged
+- All API communication uses TLS
 
 ## Observability
 
@@ -108,7 +161,19 @@ kubectl get obsykagent -n obsyk-system -o yaml
 Status conditions:
 - `Available` - Operator is running and connected
 - `Syncing` - Actively streaming data to platform
-- `Error` - Connection or configuration issue
+- `Degraded` - Connection or configuration issue
+
+### Resource Counts
+
+The status includes counts of watched resources:
+
+```yaml
+status:
+  resourceCounts:
+    namespaces: 10
+    pods: 100
+    services: 20
+```
 
 ### Logs
 
@@ -118,19 +183,31 @@ kubectl logs -n obsyk-system -l app.kubernetes.io/name=obsyk-operator
 
 ## Troubleshooting
 
-### Agent not syncing
+### Agent not connecting
 
-1. Verify the API key Secret exists:
+1. Verify the credentials Secret exists:
    ```bash
-   kubectl get secret obsyk-api-key -n obsyk-system
+   kubectl get secret obsyk-credentials -n obsyk-system
    ```
 
-2. Check operator logs for connection errors:
+2. Check the secret has the required keys:
    ```bash
-   kubectl logs -n obsyk-system -l app.kubernetes.io/name=obsyk-operator
+   kubectl get secret obsyk-credentials -n obsyk-system -o jsonpath='{.data}' | jq -r 'keys'
    ```
 
-3. Verify network connectivity to platform URL
+3. Check operator logs for authentication errors:
+   ```bash
+   kubectl logs -n obsyk-system -l app.kubernetes.io/name=obsyk-operator | grep -i error
+   ```
+
+4. Verify network connectivity to the platform URL
+
+### Agent stuck in Pending
+
+This usually means the agent hasn't sent its first heartbeat. Check:
+- The operator pod is running
+- No authentication errors in logs
+- Network connectivity to the platform
 
 ### High memory usage
 


### PR DESCRIPTION
## Summary
- Fix release workflow to clean up main checkout directory before commit
- Add .nojekyll file to prevent Jekyll processing
- Only add specific chart files instead of `git add .`
- Update README with correct OAuth2 authentication documentation
- Add detailed installation and troubleshooting instructions

## Root Cause
The release workflow was doing `git add .` which included the `main` checkout directory as a file in gh-pages, causing GitHub Pages to serve incorrect content.

## Test plan
- [ ] Merge PR and create a new release tag
- [ ] Verify `helm repo add obsyk https://obsyk.github.io/obsyk-operator` works
- [ ] Verify `helm install` succeeds from the repo

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)