### PR TITLE
[GH-28] fix: add v prefix to appVersion for image tag consistency

### DIFF
--- a/charts/obsyk-operator/Chart.yaml
+++ b/charts/obsyk-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: obsyk-operator
 description: Kubernetes operator that connects your cluster to the Obsyk observability platform
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "v0.1.0"
 kubeVersion: ">=1.26.0-0"
 home: https://obsyk.ai
 sources:


### PR DESCRIPTION
## Summary
- Fixed Helm chart appVersion to include v prefix (`v0.1.0`) to match Docker image tags
- Docker images are tagged with v prefix (e.g., `v0.1.0`) but appVersion was without it (`0.1.0`)
- This caused image pull failures when deploying via Helm chart

## Test plan
- [x] Verified Chart.yaml appVersion now matches Docker image tag format
- [ ] Deploy via Helm and confirm image pulls successfully

fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)