### PR TITLE
[GH-28] fix: automate Helm chart versioning in CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,14 @@ jobs:
           else
             echo "Helm chart not yet created, skipping lint"
           fi
+
+      - name: Validate Helm template
+        run: |
+          if [ -d "charts/obsyk-operator" ]; then
+            # Validate template renders correctly with required values
+            helm template test-release charts/obsyk-operator \
+              --set agent.clusterName=ci-test-cluster \
+              --kube-version 1.28.0 \
+              > /dev/null
+            echo "Helm template validation passed"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract version
+        id: version
+        run: |
+          # Tag is like v0.1.0, extract both formats
+          TAG="${{ github.ref_name }}"
+          # Chart version: semver without 'v' prefix (e.g., 0.1.0)
+          CHART_VERSION="${TAG#v}"
+          # App version: keeps 'v' prefix to match Docker tag (e.g., v0.1.0)
+          APP_VERSION="${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "chart=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "app=${APP_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Run CI checks
         run: earthly +ci
 
       - name: Build and push Docker image
-        run: earthly --push +docker --VERSION=${{ github.ref_name }}
+        run: earthly --push +docker --VERSION=${{ steps.version.outputs.tag }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -66,7 +79,10 @@ jobs:
       - name: Package Helm chart
         run: |
           if [ -d "charts/obsyk-operator" ]; then
-            helm package charts/obsyk-operator --version ${{ github.ref_name }} --app-version ${{ github.ref_name }}
+            # Chart version: semver (0.1.0), appVersion: Docker tag (v0.1.0)
+            helm package charts/obsyk-operator \
+              --version ${{ steps.version.outputs.chart }} \
+              --app-version ${{ steps.version.outputs.app }}
           fi
 
       - name: Create GitHub Release
@@ -109,11 +125,23 @@ jobs:
           ref: ${{ github.ref }}
           path: main
 
+      - name: Extract version
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          CHART_VERSION="${TAG#v}"
+          APP_VERSION="${TAG}"
+          echo "chart=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "app=${APP_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Package and index Helm chart
         run: |
           if [ -d "main/charts/obsyk-operator" ]; then
-            # Package the chart
-            helm package main/charts/obsyk-operator --destination .
+            # Package the chart with proper versions
+            helm package main/charts/obsyk-operator \
+              --version ${{ steps.version.outputs.chart }} \
+              --app-version ${{ steps.version.outputs.app }} \
+              --destination .
 
             # Remove the main checkout directory before adding to git
             rm -rf main

--- a/charts/obsyk-operator/Chart.yaml
+++ b/charts/obsyk-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: obsyk-operator
 description: Kubernetes operator that connects your cluster to the Obsyk observability platform
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.0-dev
+appVersion: "v0.0.0-dev"
 kubeVersion: ">=1.26.0-0"
 home: https://obsyk.ai
 sources:


### PR DESCRIPTION
## Summary
Automates Helm chart versioning so it stays in sync with Docker image tags:

- Use `0.0.0-dev` / `v0.0.0-dev` as placeholder versions in Chart.yaml for development
- Release workflow extracts version from git tag:
  - `v0.1.0` → chart version: `0.1.0` (semver), appVersion: `v0.1.0` (Docker tag)
- Add helm template validation to CI workflow to catch rendering issues early
- Apply consistent versioning to both `release` and `publish-helm` jobs

## Changes
| File | Change |
|------|--------|
| `Chart.yaml` | Use dev placeholders instead of hardcoded versions |
| `release.yml` | Add version extraction step, use proper chart/app versions |
| `ci.yml` | Add helm template validation step |

## Test plan
- [x] `helm template` renders correctly with dev version: `ghcr.io/obsyk/obsyk-operator:v0.0.0-dev`
- [ ] CI passes helm lint and template validation
- [ ] Release workflow correctly sets versions from tag

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)