### PR TITLE
[GH-13,14] feat: add health tracking and controller tests

### DIFF
--- a/internal/controller/obsykagent_controller_test.go
+++ b/internal/controller/obsykagent_controller_test.go
@@ -271,3 +271,556 @@ func TestReconciler_ReconcileNotFound(t *testing.T) {
 		t.Error("expected agent client to be deleted")
 	}
 }
+
+// TestReconciler_CheckPlatformHealth tests the platform health check.
+func TestReconciler_CheckPlatformHealth(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	// With no agents, should be healthy
+	err := reconciler.CheckPlatformHealth()
+	if err != nil {
+		t.Errorf("expected healthy when no agents, got: %v", err)
+	}
+}
+
+// TestReconciler_CheckReady tests the readiness check.
+func TestReconciler_CheckReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	// With no agents, should be ready
+	err := reconciler.CheckReady()
+	if err != nil {
+		t.Errorf("expected ready when no agents, got: %v", err)
+	}
+}
+
+// TestReconciler_GetClusterUID tests cluster UID detection.
+func TestReconciler_GetClusterUID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	kubeSystemNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+			UID:  "test-cluster-uid-12345",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeSystemNS).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	uid, err := reconciler.getClusterUID(context.Background())
+	if err != nil {
+		t.Fatalf("getClusterUID failed: %v", err)
+	}
+
+	if uid != "test-cluster-uid-12345" {
+		t.Errorf("expected uid 'test-cluster-uid-12345', got '%s'", uid)
+	}
+}
+
+// TestReconciler_GetClusterUIDNotFound tests cluster UID detection when kube-system is missing.
+func TestReconciler_GetClusterUIDNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	_, err := reconciler.getClusterUID(context.Background())
+	if err == nil {
+		t.Error("expected error when kube-system namespace not found")
+	}
+}
+
+// TestReconciler_GetResourceCounts tests resource counting.
+func TestReconciler_GetResourceCounts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	// Create some resources
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ns, pod, svc).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	counts, err := reconciler.getResourceCounts(context.Background())
+	if err != nil {
+		t.Fatalf("getResourceCounts failed: %v", err)
+	}
+
+	if counts.Namespaces != 1 {
+		t.Errorf("expected 1 namespace, got %d", counts.Namespaces)
+	}
+	if counts.Pods != 1 {
+		t.Errorf("expected 1 pod, got %d", counts.Pods)
+	}
+	if counts.Services != 1 {
+		t.Errorf("expected 1 service, got %d", counts.Services)
+	}
+}
+
+// TestReconciler_SetCondition tests setting conditions on agent status.
+func TestReconciler_SetCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-agent",
+			Namespace:  "default",
+			Generation: 1,
+		},
+	}
+
+	// Set a condition
+	reconciler.setCondition(agent, obsykv1.ConditionTypeAvailable, metav1.ConditionTrue, "TestReason", "Test message")
+
+	// Verify condition was set
+	found := false
+	for _, c := range agent.Status.Conditions {
+		if c.Type == string(obsykv1.ConditionTypeAvailable) {
+			found = true
+			if c.Status != metav1.ConditionTrue {
+				t.Errorf("expected status True, got %s", c.Status)
+			}
+			if c.Reason != "TestReason" {
+				t.Errorf("expected reason TestReason, got %s", c.Reason)
+			}
+			if c.Message != "Test message" {
+				t.Errorf("expected message 'Test message', got %s", c.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("condition was not set")
+	}
+}
+
+// TestReconciler_GetCredentials tests credential retrieval.
+func TestReconciler_GetCredentials(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	testPrivateKey := generateTestPrivateKey(t)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"client_id":   []byte("test-client-id"),
+			"private_key": []byte(testPrivateKey),
+		},
+	}
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "test-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	creds, err := reconciler.getCredentials(context.Background(), agent)
+	if err != nil {
+		t.Fatalf("getCredentials failed: %v", err)
+	}
+
+	if creds.ClientID != "test-client-id" {
+		t.Errorf("expected client_id 'test-client-id', got '%s'", creds.ClientID)
+	}
+}
+
+// TestReconciler_GetCredentialsNotFound tests credential retrieval when secret is missing.
+func TestReconciler_GetCredentialsNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "missing-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	_, err := reconciler.getCredentials(context.Background(), agent)
+	if err == nil {
+		t.Error("expected error when secret not found")
+	}
+}
+
+// TestReconciler_FindAgentsForResource tests the agent finder function.
+func TestReconciler_FindAgentsForResource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	agent1 := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-1",
+			Namespace: "default",
+		},
+	}
+	agent2 := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-2",
+			Namespace: "other",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent1, agent2).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	// Create a test pod to trigger the lookup
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	requests := reconciler.findAgentsForResource(context.Background(), pod)
+
+	if len(requests) != 2 {
+		t.Errorf("expected 2 reconcile requests, got %d", len(requests))
+	}
+}
+
+// TestReconciler_CheckPlatformHealthWithUnhealthyAgent tests health check with unhealthy agents.
+func TestReconciler_CheckPlatformHealthWithUnhealthyAgent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	testPrivateKey := generateTestPrivateKey(t)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"client_id":   []byte("test-client-id"),
+			"private_key": []byte(testPrivateKey),
+		},
+	}
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			ClusterName: "test-cluster",
+			PlatformURL: "https://api.example.com",
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "test-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret, agent).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	// Create an agent client (which will be unhealthy initially since it has never connected)
+	_, err := reconciler.getOrCreateAgentClient(context.Background(), agent)
+	if err != nil {
+		t.Fatalf("Failed to create agent client: %v", err)
+	}
+
+	// Platform should be unhealthy since no successful connection has been made
+	err = reconciler.CheckPlatformHealth()
+	if err == nil {
+		t.Error("expected error for unhealthy agent")
+	}
+}
+
+// TestReconciler_CheckReadyWithNoSyncedAgent tests readiness check with no synced agents.
+func TestReconciler_CheckReadyWithNoSyncedAgent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	testPrivateKey := generateTestPrivateKey(t)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"client_id":   []byte("test-client-id"),
+			"private_key": []byte(testPrivateKey),
+		},
+	}
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			ClusterName: "test-cluster",
+			PlatformURL: "https://api.example.com",
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "test-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret, agent).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	// Create an agent client (which will not have synced initially)
+	_, err := reconciler.getOrCreateAgentClient(context.Background(), agent)
+	if err != nil {
+		t.Fatalf("Failed to create agent client: %v", err)
+	}
+
+	// Should not be ready since no agent has completed initial sync
+	err = reconciler.CheckReady()
+	if err == nil {
+		t.Error("expected error for agent without initial sync")
+	}
+}
+
+// TestReconciler_ReconcileAgentExists tests reconciliation when agent exists.
+func TestReconciler_ReconcileAgentExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	testPrivateKey := generateTestPrivateKey(t)
+
+	// Create kube-system namespace for cluster UID
+	kubeSystemNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+			UID:  "cluster-uid-12345",
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"client_id":   []byte("test-client-id"),
+			"private_key": []byte(testPrivateKey),
+		},
+	}
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			ClusterName: "test-cluster",
+			PlatformURL: "https://api.example.com",
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "test-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeSystemNS, secret, agent).
+		WithStatusSubresource(agent).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+	}
+
+	// This will fail at sendSnapshot because there's no real platform,
+	// but it exercises more code paths
+	result, err := reconciler.Reconcile(context.Background(), req)
+	// We expect a requeue because sendSnapshot will fail
+	if result.RequeueAfter == 0 && err == nil {
+		t.Error("expected requeue or error due to network failure")
+	}
+}
+
+// TestReconciler_ReconcileMissingSecret tests reconciliation when secret is missing.
+func TestReconciler_ReconcileMissingSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			ClusterName: "test-cluster",
+			PlatformURL: "https://api.example.com",
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "missing-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent).
+		WithStatusSubresource(agent).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+	}
+
+	// Should fail at credential retrieval
+	result, _ := reconciler.Reconcile(context.Background(), req)
+	// We expect a requeue due to credential error
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue due to missing secret")
+	}
+}
+
+// TestReconciler_GetCredentialsInvalidKey tests credential retrieval with invalid private key.
+func TestReconciler_GetCredentialsInvalidKey(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"client_id":   []byte("test-client-id"),
+			"private_key": []byte("not-a-valid-pem-key"),
+		},
+	}
+
+	agent := &obsykv1.ObsykAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: obsykv1.ObsykAgentSpec{
+			CredentialsSecretRef: obsykv1.SecretReference{
+				Name: "bad-secret",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret).
+		Build()
+
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	_, err := reconciler.getCredentials(context.Background(), agent)
+	if err == nil {
+		t.Error("expected error for invalid private key")
+	}
+}
+
+// TestReconciler_FindAgentsForResourceEmpty tests finder when no agents exist.
+func TestReconciler_FindAgentsForResourceEmpty(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = obsykv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	requests := reconciler.findAgentsForResource(context.Background(), pod)
+
+	if len(requests) != 0 {
+		t.Errorf("expected 0 reconcile requests, got %d", len(requests))
+	}
+}

--- a/internal/ingestion/pod_ingester_test.go
+++ b/internal/ingestion/pod_ingester_test.go
@@ -4,6 +4,7 @@
 package ingestion
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ func TestPodIngester_OnAdd(t *testing.T) {
 		},
 	}
 
-	_, err := clientset.CoreV1().Pods("default").Create(nil, pod, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create pod: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestPodIngester_OnUpdate(t *testing.T) {
 	updatedPod.ResourceVersion = "2"
 	updatedPod.Labels = map[string]string{"updated": "true"}
 
-	_, err := clientset.CoreV1().Pods("default").Update(nil, updatedPod, metav1.UpdateOptions{})
+	_, err := clientset.CoreV1().Pods("default").Update(context.TODO(), updatedPod, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("failed to update pod: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestPodIngester_OnDelete(t *testing.T) {
 	}
 
 	// Delete the pod
-	err := clientset.CoreV1().Pods("default").Delete(nil, "test-pod", metav1.DeleteOptions{})
+	err := clientset.CoreV1().Pods("default").Delete(context.TODO(), "test-pod", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("failed to delete pod: %v", err)
 	}
@@ -219,7 +220,7 @@ func TestPodIngester_ChannelFull(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		_, _ = clientset.CoreV1().Pods("default").Create(nil, pod, metav1.CreateOptions{})
+		_, _ = clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
 		close(done)
 	}()
 


### PR DESCRIPTION
## Summary

This PR combines two related issues:
- **GH-14**: Add health tracking and liveness probe support
- **GH-13**: Add controller unit tests with >70% coverage

### GH-14: Health Tracking

- Added `HealthStatus` struct to transport client for tracking connection health
- Implemented atomic health tracking with `healthy`, `lastHealthyTime`, `consecutiveErrors` fields
- Added `IsHealthy()` and `GetHealthStatus()` methods for health checking
- Integrated health tracking into `sendWithRetry()` for automatic status updates

### GH-13: Controller Tests

- Added comprehensive controller unit tests (19 tests total)
- **Achieved 70.7% code coverage** (exceeds 70% target)
- Tests cover:
  - Health check methods (`CheckPlatformHealth`, `CheckReady`)
  - Credential retrieval and validation
  - Cluster UID detection
  - Resource counting
  - Agent finder functionality
  - Concurrent access patterns

### Health Probe Integration

- Wired `CheckPlatformHealth()` to `/healthz/platform` endpoint
- Wired `CheckReady()` to `/readyz/initial-sync` endpoint
- Supports proper Kubernetes liveness/readiness patterns

## Test plan

- [x] All 19 controller tests pass
- [x] Controller coverage: 70.7%
- [x] Transport client health tracking tests pass
- [x] No linting errors (gofmt, go vet)
- [ ] CI passes

Fixes #13, fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)