### PR TITLE
[GH-52] Fix cluster-scoped secret watch by using APIReader

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,8 +64,10 @@ func main() {
 	}
 
 	// Register ObsykAgent controller
+	// Pass APIReader for direct API calls (secrets) without cluster-wide caching
 	reconciler := controller.NewObsykAgentReconciler(
 		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		mgr.GetScheme(),
 	)
 	if err = reconciler.SetupWithManager(mgr); err != nil {

--- a/internal/controller/obsykagent_controller_test.go
+++ b/internal/controller/obsykagent_controller_test.go
@@ -53,7 +53,7 @@ func TestNewObsykAgentReconciler(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	if reconciler == nil {
 		t.Fatal("expected non-nil reconciler")
@@ -111,7 +111,7 @@ func TestReconciler_ConcurrentAgentClientAccess(t *testing.T) {
 	}
 	fakeClient := clientBuilder.Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// Concurrently call getOrCreateAgentClient for different agents
 	var wg sync.WaitGroup
@@ -184,7 +184,7 @@ func TestReconciler_ConcurrentDeleteAndCreate(t *testing.T) {
 		WithObjects(secret, agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -239,7 +239,7 @@ func TestReconciler_ReconcileNotFound(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// Pre-populate with a client that should be deleted
 	reconciler.agentClientsMu.Lock()
@@ -279,7 +279,7 @@ func TestReconciler_CheckPlatformHealth(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// With no agents, should be healthy
 	err := reconciler.CheckPlatformHealth()
@@ -295,7 +295,7 @@ func TestReconciler_CheckReady(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// With no agents, should be ready
 	err := reconciler.CheckReady()
@@ -322,7 +322,7 @@ func TestReconciler_GetClusterUID(t *testing.T) {
 		WithObjects(kubeSystemNS).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	uid, err := reconciler.getClusterUID(context.Background())
 	if err != nil {
@@ -341,7 +341,7 @@ func TestReconciler_GetClusterUIDNotFound(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	_, err := reconciler.getClusterUID(context.Background())
 	if err == nil {
@@ -371,7 +371,7 @@ func TestReconciler_GetResourceCounts(t *testing.T) {
 		WithObjects(ns, pod, svc).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	counts, err := reconciler.getResourceCounts(context.Background())
 	if err != nil {
@@ -396,7 +396,7 @@ func TestReconciler_SetCondition(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	agent := &obsykv1.ObsykAgent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -466,7 +466,7 @@ func TestReconciler_GetCredentials(t *testing.T) {
 		WithObjects(secret).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	creds, err := reconciler.getCredentials(context.Background(), agent)
 	if err != nil {
@@ -497,7 +497,7 @@ func TestReconciler_GetCredentialsNotFound(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	_, err := reconciler.getCredentials(context.Background(), agent)
 	if err == nil {
@@ -529,7 +529,7 @@ func TestReconciler_FindAgentsForResource(t *testing.T) {
 		WithObjects(agent1, agent2).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// Create a test pod to trigger the lookup
 	pod := &corev1.Pod{
@@ -584,7 +584,7 @@ func TestReconciler_CheckPlatformHealthWithUnhealthyAgent(t *testing.T) {
 		WithObjects(secret, agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// Create an agent client (which will be unhealthy initially since it has never connected)
 	_, err := reconciler.getOrCreateAgentClient(context.Background(), agent)
@@ -637,7 +637,7 @@ func TestReconciler_CheckReadyWithNoSyncedAgent(t *testing.T) {
 		WithObjects(secret, agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	// Create an agent client (which will not have synced initially)
 	_, err := reconciler.getOrCreateAgentClient(context.Background(), agent)
@@ -699,7 +699,7 @@ func TestReconciler_ReconcileAgentExists(t *testing.T) {
 		WithStatusSubresource(agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -743,7 +743,7 @@ func TestReconciler_ReconcileMissingSecret(t *testing.T) {
 		WithStatusSubresource(agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -794,7 +794,7 @@ func TestReconciler_GetCredentialsInvalidKey(t *testing.T) {
 		WithObjects(secret).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	_, err := reconciler.getCredentials(context.Background(), agent)
 	if err == nil {
@@ -809,7 +809,7 @@ func TestReconciler_FindAgentsForResourceEmpty(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, scheme)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- Use `mgr.GetAPIReader()` instead of cached client for reading secrets
- This avoids controller-runtime setting up a cluster-wide watch on secrets
- Removed cluster-scoped RBAC marker for secrets (namespaced Role handles access)

## Problem
The controller was using `r.Get()` (cached client) to fetch the credentials secret, which caused controller-runtime to set up a **cluster-wide watch on all Secrets**. This required cluster-scope RBAC that we don't provide, causing:
- E2E test failures
- Continuous "cannot list secrets at cluster scope" errors in logs

## Solution
Use `APIReader` which makes direct API calls without caching, avoiding the cluster-wide watch setup.

## Changes
- Add `APIReader` field to `ObsykAgentReconciler` struct
- Pass `mgr.GetAPIReader()` from main.go
- Use `APIReader.Get()` in `getCredentials()` 
- Remove cluster-scoped secrets RBAC marker
- Update all tests

Fixes #52

## Test plan
- [x] Unit tests pass locally
- [ ] CI checks pass
- [ ] E2E tests pass (this should fix them!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)