### PR TITLE
[GH-53] Add events RBAC permission for leader election

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -69,3 +69,11 @@ rules:
       - patch
       - update
       - watch
+  # Events for leader election announcements
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch


### PR DESCRIPTION
## Summary
- Add `events` create/patch permissions to ClusterRole
- Fixes warning logs during leader election

## Problem
The operator logs warnings about being unable to create events:
```
Server rejected event (will not retry!) err="events is forbidden..."
```

## Solution
Added events permission to allow leader election event announcements.

Fixes #53

## Test plan
- [ ] CI checks pass
- [ ] No more "events is forbidden" warnings in logs after Helm upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)