### PR TITLE
fix: clear Degraded condition on successful reconcile

### DIFF
--- a/internal/controller/obsykagent_controller.go
+++ b/internal/controller/obsykagent_controller.go
@@ -146,11 +146,13 @@ func (r *ObsykAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		agent.Status.ResourceCounts = counts
 	}
 
-	// Set healthy conditions
+	// Set healthy conditions and clear any degraded state
 	r.setCondition(agent, obsykv1.ConditionTypeAvailable, metav1.ConditionTrue,
 		"AgentRunning", "Agent is running and connected to platform")
 	r.setCondition(agent, obsykv1.ConditionTypeSyncing, metav1.ConditionTrue,
 		"SyncActive", "Agent is actively syncing data")
+	r.setCondition(agent, obsykv1.ConditionTypeDegraded, metav1.ConditionFalse,
+		"AgentHealthy", "Agent is operating normally")
 
 	// Update observed generation
 	agent.Status.ObservedGeneration = agent.Generation


### PR DESCRIPTION
## Summary
- Fixes stale Degraded condition that persisted after successful recovery
- On every successful reconcile, explicitly sets Degraded condition to False

## Problem
When the controller encountered an error (e.g., missing credentials secret), it would set the `Degraded` condition to `True`. However, when the issue was resolved and the agent successfully connected, the `Degraded` condition was never cleared, leaving a stale error message visible in the agent status.

## Solution
Added explicit clearing of the `Degraded` condition when the reconcile completes successfully, setting it to `False` with reason `AgentHealthy`.

## Test plan
- [x] Unit tests pass
- [ ] Manual verification: observe Degraded condition is cleared after recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)