### PR TITLE
[GH-59] feat: add Deployment collection for workload visibility

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -61,6 +61,13 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list
+      - watch
   # Note: Secret access is granted via Role (namespace-scoped) for least privilege
   # See role.yaml for secret access in the operator namespace only
   # Leader election

--- a/internal/ingestion/deployment_ingester.go
+++ b/internal/ingestion/deployment_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// DeploymentIngester watches Deployment resources and sends events to the event channel.
+type DeploymentIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewDeploymentIngester creates a new DeploymentIngester.
+func NewDeploymentIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *DeploymentIngester {
+	return &DeploymentIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("deployment-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (d *DeploymentIngester) RegisterHandlers() {
+	informer := d.informerFactory.Apps().V1().Deployments().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    d.onAdd,
+		UpdateFunc: d.onUpdate,
+		DeleteFunc: d.onDelete,
+	})
+	if err != nil {
+		d.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles Deployment addition events.
+func (d *DeploymentIngester) onAdd(obj interface{}) {
+	deploy, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		d.log.Error(nil, "received non-Deployment object in add handler")
+		return
+	}
+
+	d.log.V(2).Info("deployment added",
+		"name", deploy.Name,
+		"namespace", deploy.Namespace,
+		"uid", deploy.UID)
+
+	d.sendEvent(transport.EventTypeAdded, deploy)
+}
+
+// onUpdate handles Deployment update events.
+func (d *DeploymentIngester) onUpdate(oldObj, newObj interface{}) {
+	oldDeploy, ok := oldObj.(*appsv1.Deployment)
+	if !ok {
+		return
+	}
+	newDeploy, ok := newObj.(*appsv1.Deployment)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldDeploy.ResourceVersion == newDeploy.ResourceVersion {
+		return
+	}
+
+	d.log.V(2).Info("deployment updated",
+		"name", newDeploy.Name,
+		"namespace", newDeploy.Namespace,
+		"uid", newDeploy.UID)
+
+	d.sendEvent(transport.EventTypeUpdated, newDeploy)
+}
+
+// onDelete handles Deployment deletion events.
+func (d *DeploymentIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	deploy, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		d.log.Error(nil, "received non-Deployment object in delete handler")
+		return
+	}
+
+	d.log.V(2).Info("deployment deleted",
+		"name", deploy.Name,
+		"namespace", deploy.Namespace,
+		"uid", deploy.UID)
+
+	// For delete events, we only need identifying info, not full object
+	d.sendDeleteEvent(deploy)
+}
+
+// sendEvent sends a Deployment event to the event channel.
+func (d *DeploymentIngester) sendEvent(eventType transport.EventType, deploy *appsv1.Deployment) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeDeployment,
+		UID:       string(deploy.UID),
+		Name:      deploy.Name,
+		Namespace: deploy.Namespace,
+		Object:    transport.NewDeploymentInfo(deploy),
+	}
+
+	select {
+	case d.config.EventChan <- event:
+	default:
+		d.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", deploy.Name,
+			"namespace", deploy.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a Deployment delete event (without full object data).
+func (d *DeploymentIngester) sendDeleteEvent(deploy *appsv1.Deployment) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeDeployment,
+		UID:       string(deploy.UID),
+		Name:      deploy.Name,
+		Namespace: deploy.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case d.config.EventChan <- event:
+	default:
+		d.log.Error(nil, "event channel full, dropping delete event",
+			"name", deploy.Name,
+			"namespace", deploy.Namespace)
+	}
+}

--- a/internal/ingestion/deployment_ingester_test.go
+++ b/internal/ingestion/deployment_ingester_test.go
@@ -1,0 +1,507 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestDeploymentIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a deployment
+	replicas := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+			UID:       "deploy-uid-123",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:latest"},
+					},
+				},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas:     2,
+			AvailableReplicas: 2,
+			UpdatedReplicas:   3,
+		},
+	}
+
+	_, err := clientset.AppsV1().Deployments("default").Create(context.TODO(), deploy, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create deployment: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeDeployment {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeDeployment)
+		}
+		if event.Name != "test-deployment" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-deployment")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "deploy-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "deploy-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify DeploymentInfo data
+		deployInfo, ok := event.Object.(transport.DeploymentInfo)
+		if !ok {
+			t.Errorf("Object is not DeploymentInfo: %T", event.Object)
+		} else {
+			if deployInfo.Replicas != 3 {
+				t.Errorf("Replicas = %d, want 3", deployInfo.Replicas)
+			}
+			if deployInfo.Image != "nginx:latest" {
+				t.Errorf("Image = %s, want nginx:latest", deployInfo.Image)
+			}
+			if deployInfo.Strategy != "RollingUpdate" {
+				t.Errorf("Strategy = %s, want RollingUpdate", deployInfo.Strategy)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestDeploymentIngester_OnUpdate(t *testing.T) {
+	// Create initial deployment
+	replicas := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-deployment",
+			Namespace:       "default",
+			UID:             "deploy-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deploy)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the deployment
+	updatedDeploy := deploy.DeepCopy()
+	updatedDeploy.ResourceVersion = "2"
+	newReplicas := int32(5)
+	updatedDeploy.Spec.Replicas = &newReplicas
+
+	_, err := clientset.AppsV1().Deployments("default").Update(context.TODO(), updatedDeploy, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update deployment: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeDeployment {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeDeployment)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestDeploymentIngester_OnDelete(t *testing.T) {
+	// Create initial deployment
+	replicas := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+			UID:       "deploy-uid-123",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deploy)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the deployment
+	err := clientset.AppsV1().Deployments("default").Delete(context.TODO(), "test-deployment", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete deployment: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeDeployment {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeDeployment)
+		}
+		if event.Name != "test-deployment" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-deployment")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestDeploymentIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a deployment - this should not block even though channel is full
+	replicas := int32(1)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+			UID:       "deploy-uid-123",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.AppsV1().Deployments("default").Create(context.TODO(), deploy, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestDeploymentIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial deployment
+	replicas := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-deployment",
+			Namespace:       "default",
+			UID:             "deploy-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deploy)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(deploy, deploy)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}
+
+func TestNewDeploymentInfo(t *testing.T) {
+	testCases := []struct {
+		name             string
+		deploy           *appsv1.Deployment
+		expectedReplicas int32
+		expectedImage    string
+		expectedStrategy string
+	}{
+		{
+			name: "deployment with all fields",
+			deploy: func() *appsv1.Deployment {
+				replicas := int32(5)
+				return &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+						UID:       "uid-123",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &replicas,
+						Strategy: appsv1.DeploymentStrategy{
+							Type: appsv1.RollingUpdateDeploymentStrategyType,
+						},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "main", Image: "nginx:1.19"},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			expectedReplicas: 5,
+			expectedImage:    "nginx:1.19",
+			expectedStrategy: "RollingUpdate",
+		},
+		{
+			name: "deployment with nil replicas (defaults to 1)",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Image: "app:latest"},
+							},
+						},
+					},
+				},
+			},
+			expectedReplicas: 1,
+			expectedImage:    "app:latest",
+			expectedStrategy: "",
+		},
+		{
+			name: "deployment with no containers",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{},
+						},
+					},
+				},
+			},
+			expectedReplicas: 1,
+			expectedImage:    "",
+			expectedStrategy: "",
+		},
+		{
+			name: "deployment with Recreate strategy",
+			deploy: func() *appsv1.Deployment {
+				replicas := int32(2)
+				return &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &replicas,
+						Strategy: appsv1.DeploymentStrategy{
+							Type: appsv1.RecreateDeploymentStrategyType,
+						},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "main", Image: "app:v2"},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			expectedReplicas: 2,
+			expectedImage:    "app:v2",
+			expectedStrategy: "Recreate",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := transport.NewDeploymentInfo(tc.deploy)
+
+			if info.Replicas != tc.expectedReplicas {
+				t.Errorf("Replicas = %d, want %d", info.Replicas, tc.expectedReplicas)
+			}
+			if info.Image != tc.expectedImage {
+				t.Errorf("Image = %s, want %s", info.Image, tc.expectedImage)
+			}
+			if info.Strategy != tc.expectedStrategy {
+				t.Errorf("Strategy = %s, want %s", info.Strategy, tc.expectedStrategy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DeploymentInfo` type to `internal/transport/types.go`
- Add `ResourceTypeDeployment` constant
- Create `deployment_ingester.go` for event watching
- Update `IngestionManager` to watch Deployments via SharedInformerFactory
- Add Deployments to `SnapshotPayload` for initial snapshot
- Update RBAC `clusterrole.yaml` to allow list/watch on apps/deployments

## Data Collected
- UID, Name, Namespace, Labels, Annotations
- Replicas (desired, ready, available, updated)
- Strategy (RollingUpdate/Recreate)
- Selector (match labels)
- Image (primary container image)

## Test plan
- [x] Unit tests for add/update/delete events
- [x] Tests for channel full scenario (non-blocking)
- [x] Tests for same resource version skip
- [x] Tests for NewDeploymentInfo helper function
- [x] All existing tests pass

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)