### PR TITLE
[GH-60] feat: add StatefulSet ingestion

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -68,6 +68,13 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - list
+      - watch
   # Note: Secret access is granted via Role (namespace-scoped) for least privilege
   # See role.yaml for secret access in the operator namespace only
   # Leader election

--- a/internal/ingestion/statefulset_ingester.go
+++ b/internal/ingestion/statefulset_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// StatefulSetIngester watches StatefulSet resources and sends events to the event channel.
+type StatefulSetIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewStatefulSetIngester creates a new StatefulSetIngester.
+func NewStatefulSetIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *StatefulSetIngester {
+	return &StatefulSetIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("statefulset-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (s *StatefulSetIngester) RegisterHandlers() {
+	informer := s.informerFactory.Apps().V1().StatefulSets().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    s.onAdd,
+		UpdateFunc: s.onUpdate,
+		DeleteFunc: s.onDelete,
+	})
+	if err != nil {
+		s.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles StatefulSet addition events.
+func (s *StatefulSetIngester) onAdd(obj interface{}) {
+	sts, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		s.log.Error(nil, "received non-StatefulSet object in add handler")
+		return
+	}
+
+	s.log.V(2).Info("statefulset added",
+		"name", sts.Name,
+		"namespace", sts.Namespace,
+		"uid", sts.UID)
+
+	s.sendEvent(transport.EventTypeAdded, sts)
+}
+
+// onUpdate handles StatefulSet update events.
+func (s *StatefulSetIngester) onUpdate(oldObj, newObj interface{}) {
+	oldSts, ok := oldObj.(*appsv1.StatefulSet)
+	if !ok {
+		return
+	}
+	newSts, ok := newObj.(*appsv1.StatefulSet)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldSts.ResourceVersion == newSts.ResourceVersion {
+		return
+	}
+
+	s.log.V(2).Info("statefulset updated",
+		"name", newSts.Name,
+		"namespace", newSts.Namespace,
+		"uid", newSts.UID)
+
+	s.sendEvent(transport.EventTypeUpdated, newSts)
+}
+
+// onDelete handles StatefulSet deletion events.
+func (s *StatefulSetIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	sts, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		s.log.Error(nil, "received non-StatefulSet object in delete handler")
+		return
+	}
+
+	s.log.V(2).Info("statefulset deleted",
+		"name", sts.Name,
+		"namespace", sts.Namespace,
+		"uid", sts.UID)
+
+	// For delete events, we only need identifying info, not full object
+	s.sendDeleteEvent(sts)
+}
+
+// sendEvent sends a StatefulSet event to the event channel.
+func (s *StatefulSetIngester) sendEvent(eventType transport.EventType, sts *appsv1.StatefulSet) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeStatefulSet,
+		UID:       string(sts.UID),
+		Name:      sts.Name,
+		Namespace: sts.Namespace,
+		Object:    transport.NewStatefulSetInfo(sts),
+	}
+
+	select {
+	case s.config.EventChan <- event:
+	default:
+		s.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", sts.Name,
+			"namespace", sts.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a StatefulSet delete event (without full object data).
+func (s *StatefulSetIngester) sendDeleteEvent(sts *appsv1.StatefulSet) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeStatefulSet,
+		UID:       string(sts.UID),
+		Name:      sts.Name,
+		Namespace: sts.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case s.config.EventChan <- event:
+	default:
+		s.log.Error(nil, "event channel full, dropping delete event",
+			"name", sts.Name,
+			"namespace", sts.Namespace)
+	}
+}

--- a/internal/ingestion/statefulset_ingester_test.go
+++ b/internal/ingestion/statefulset_ingester_test.go
@@ -1,0 +1,505 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestStatefulSetIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a statefulset
+	replicas := int32(3)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "default",
+			UID:       "sts-uid-123",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: "test-headless",
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "postgres:14"},
+					},
+				},
+			},
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:   2,
+			CurrentReplicas: 3,
+		},
+	}
+
+	_, err := clientset.AppsV1().StatefulSets("default").Create(context.TODO(), sts, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create statefulset: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeStatefulSet {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeStatefulSet)
+		}
+		if event.Name != "test-statefulset" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-statefulset")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "sts-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "sts-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify StatefulSetInfo data
+		stsInfo, ok := event.Object.(transport.StatefulSetInfo)
+		if !ok {
+			t.Errorf("Object is not StatefulSetInfo: %T", event.Object)
+		} else {
+			if stsInfo.Replicas != 3 {
+				t.Errorf("Replicas = %d, want 3", stsInfo.Replicas)
+			}
+			if stsInfo.ServiceName != "test-headless" {
+				t.Errorf("ServiceName = %s, want test-headless", stsInfo.ServiceName)
+			}
+			if stsInfo.Image != "postgres:14" {
+				t.Errorf("Image = %s, want postgres:14", stsInfo.Image)
+			}
+			if stsInfo.UpdateStrategy != "RollingUpdate" {
+				t.Errorf("UpdateStrategy = %s, want RollingUpdate", stsInfo.UpdateStrategy)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestStatefulSetIngester_OnUpdate(t *testing.T) {
+	// Create initial statefulset
+	replicas := int32(3)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-statefulset",
+			Namespace:       "default",
+			UID:             "sts-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: "test-headless",
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "postgres:14"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(sts)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the statefulset
+	updatedSts := sts.DeepCopy()
+	updatedSts.ResourceVersion = "2"
+	newReplicas := int32(5)
+	updatedSts.Spec.Replicas = &newReplicas
+
+	_, err := clientset.AppsV1().StatefulSets("default").Update(context.TODO(), updatedSts, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update statefulset: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeStatefulSet {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeStatefulSet)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestStatefulSetIngester_OnDelete(t *testing.T) {
+	// Create initial statefulset
+	replicas := int32(3)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "default",
+			UID:       "sts-uid-123",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: "test-headless",
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "postgres:14"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(sts)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the statefulset
+	err := clientset.AppsV1().StatefulSets("default").Delete(context.TODO(), "test-statefulset", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete statefulset: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeStatefulSet {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeStatefulSet)
+		}
+		if event.Name != "test-statefulset" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-statefulset")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestStatefulSetIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a statefulset - this should not block even though channel is full
+	replicas := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "default",
+			UID:       "sts-uid-123",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: "test-headless",
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "postgres:14"},
+					},
+				},
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.AppsV1().StatefulSets("default").Create(context.TODO(), sts, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestStatefulSetIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial statefulset
+	replicas := int32(3)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-statefulset",
+			Namespace:       "default",
+			UID:             "sts-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: "test-headless",
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "postgres:14"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(sts)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(sts, sts)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}
+
+func TestNewStatefulSetInfo(t *testing.T) {
+	testCases := []struct {
+		name             string
+		sts              *appsv1.StatefulSet
+		expectedReplicas int32
+		expectedImage    string
+		expectedStrategy string
+		expectedSvcName  string
+	}{
+		{
+			name: "statefulset with all fields",
+			sts: func() *appsv1.StatefulSet {
+				replicas := int32(5)
+				return &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+						UID:       "uid-123",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas:    &replicas,
+						ServiceName: "test-headless",
+						UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+							Type: appsv1.RollingUpdateStatefulSetStrategyType,
+						},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "main", Image: "postgres:14"},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			expectedReplicas: 5,
+			expectedImage:    "postgres:14",
+			expectedStrategy: "RollingUpdate",
+			expectedSvcName:  "test-headless",
+		},
+		{
+			name: "statefulset with nil replicas (defaults to 1)",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					ServiceName: "test-svc",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Image: "mysql:8"},
+							},
+						},
+					},
+				},
+			},
+			expectedReplicas: 1,
+			expectedImage:    "mysql:8",
+			expectedStrategy: "",
+			expectedSvcName:  "test-svc",
+		},
+		{
+			name: "statefulset with OnDelete strategy",
+			sts: func() *appsv1.StatefulSet {
+				replicas := int32(2)
+				return &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas:    &replicas,
+						ServiceName: "test-svc",
+						UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+							Type: appsv1.OnDeleteStatefulSetStrategyType,
+						},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "main", Image: "redis:7"},
+								},
+							},
+						},
+					},
+				}
+			}(),
+			expectedReplicas: 2,
+			expectedImage:    "redis:7",
+			expectedStrategy: "OnDelete",
+			expectedSvcName:  "test-svc",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := transport.NewStatefulSetInfo(tc.sts)
+
+			if info.Replicas != tc.expectedReplicas {
+				t.Errorf("Replicas = %d, want %d", info.Replicas, tc.expectedReplicas)
+			}
+			if info.Image != tc.expectedImage {
+				t.Errorf("Image = %s, want %s", info.Image, tc.expectedImage)
+			}
+			if info.UpdateStrategy != tc.expectedStrategy {
+				t.Errorf("UpdateStrategy = %s, want %s", info.UpdateStrategy, tc.expectedStrategy)
+			}
+			if info.ServiceName != tc.expectedSvcName {
+				t.Errorf("ServiceName = %s, want %s", info.ServiceName, tc.expectedSvcName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add StatefulSetIngester following the pod_ingester.go pattern with event handlers for Add/Update/Delete
- Add StatefulSetInfo type to transport/types.go with fields for replicas, serviceName, updateStrategy
- Add NewStatefulSetInfo helper function for conversion from Kubernetes StatefulSet
- Update IngestionManager to include statefulsetIngester and coordinate watching
- Add RBAC permissions for statefulsets (list, watch) in ClusterRole
- Add comprehensive tests for StatefulSet ingestion including add/update/delete/channel full scenarios

## Test plan
- [x] Unit tests for StatefulSetIngester (add/update/delete events)
- [x] Unit tests for NewStatefulSetInfo helper function
- [x] Tests for channel full behavior
- [x] Tests for nil replicas handling
- [x] All existing tests pass
- [x] gofmt check passes

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)