### PR TITLE
[GH-62] feat: add Job and CronJob ingestion

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -82,6 +82,20 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - watch
   # Note: Secret access is granted via Role (namespace-scoped) for least privilege
   # See role.yaml for secret access in the operator namespace only
   # Leader election

--- a/internal/ingestion/cronjob_ingester.go
+++ b/internal/ingestion/cronjob_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CronJobIngester watches CronJob resources and sends events to the event channel.
+type CronJobIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewCronJobIngester creates a new CronJobIngester.
+func NewCronJobIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *CronJobIngester {
+	return &CronJobIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("cronjob-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (c *CronJobIngester) RegisterHandlers() {
+	informer := c.informerFactory.Batch().V1().CronJobs().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onAdd,
+		UpdateFunc: c.onUpdate,
+		DeleteFunc: c.onDelete,
+	})
+	if err != nil {
+		c.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles CronJob addition events.
+func (c *CronJobIngester) onAdd(obj interface{}) {
+	cj, ok := obj.(*batchv1.CronJob)
+	if !ok {
+		c.log.Error(nil, "received non-CronJob object in add handler")
+		return
+	}
+
+	c.log.V(2).Info("cronjob added",
+		"name", cj.Name,
+		"namespace", cj.Namespace,
+		"uid", cj.UID)
+
+	c.sendEvent(transport.EventTypeAdded, cj)
+}
+
+// onUpdate handles CronJob update events.
+func (c *CronJobIngester) onUpdate(oldObj, newObj interface{}) {
+	oldCJ, ok := oldObj.(*batchv1.CronJob)
+	if !ok {
+		return
+	}
+	newCJ, ok := newObj.(*batchv1.CronJob)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldCJ.ResourceVersion == newCJ.ResourceVersion {
+		return
+	}
+
+	c.log.V(2).Info("cronjob updated",
+		"name", newCJ.Name,
+		"namespace", newCJ.Namespace,
+		"uid", newCJ.UID)
+
+	c.sendEvent(transport.EventTypeUpdated, newCJ)
+}
+
+// onDelete handles CronJob deletion events.
+func (c *CronJobIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	cj, ok := obj.(*batchv1.CronJob)
+	if !ok {
+		c.log.Error(nil, "received non-CronJob object in delete handler")
+		return
+	}
+
+	c.log.V(2).Info("cronjob deleted",
+		"name", cj.Name,
+		"namespace", cj.Namespace,
+		"uid", cj.UID)
+
+	// For delete events, we only need identifying info, not full object
+	c.sendDeleteEvent(cj)
+}
+
+// sendEvent sends a CronJob event to the event channel.
+func (c *CronJobIngester) sendEvent(eventType transport.EventType, cj *batchv1.CronJob) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeCronJob,
+		UID:       string(cj.UID),
+		Name:      cj.Name,
+		Namespace: cj.Namespace,
+		Object:    transport.NewCronJobInfo(cj),
+	}
+
+	select {
+	case c.config.EventChan <- event:
+	default:
+		c.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", cj.Name,
+			"namespace", cj.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a CronJob delete event (without full object data).
+func (c *CronJobIngester) sendDeleteEvent(cj *batchv1.CronJob) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeCronJob,
+		UID:       string(cj.UID),
+		Name:      cj.Name,
+		Namespace: cj.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case c.config.EventChan <- event:
+	default:
+		c.log.Error(nil, "event channel full, dropping delete event",
+			"name", cj.Name,
+			"namespace", cj.Namespace)
+	}
+}

--- a/internal/ingestion/cronjob_ingester_test.go
+++ b/internal/ingestion/cronjob_ingester_test.go
@@ -1,0 +1,309 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestCronJobIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a cronjob
+	suspend := false
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cronjob",
+			Namespace: "default",
+			UID:       "cj-uid-123",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          "*/5 * * * *",
+			Suspend:           &suspend,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+		},
+	}
+
+	_, err := clientset.BatchV1().CronJobs("default").Create(context.TODO(), cj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create cronjob: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeCronJob {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeCronJob)
+		}
+		if event.Name != "test-cronjob" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-cronjob")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "cj-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "cj-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify CronJobInfo data
+		cjInfo, ok := event.Object.(transport.CronJobInfo)
+		if !ok {
+			t.Errorf("Object is not CronJobInfo: %T", event.Object)
+		} else {
+			if cjInfo.Schedule != "*/5 * * * *" {
+				t.Errorf("Schedule = %s, want */5 * * * *", cjInfo.Schedule)
+			}
+			if cjInfo.Suspend != false {
+				t.Errorf("Suspend = %v, want false", cjInfo.Suspend)
+			}
+			if cjInfo.ConcurrencyPolicy != "Forbid" {
+				t.Errorf("ConcurrencyPolicy = %s, want Forbid", cjInfo.ConcurrencyPolicy)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestCronJobIngester_OnUpdate(t *testing.T) {
+	// Create initial cronjob
+	suspend := false
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cronjob",
+			Namespace:       "default",
+			UID:             "cj-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/5 * * * *",
+			Suspend:  &suspend,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(cj)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the cronjob
+	updatedCJ := cj.DeepCopy()
+	updatedCJ.ResourceVersion = "2"
+	newSuspend := true
+	updatedCJ.Spec.Suspend = &newSuspend
+
+	_, err := clientset.BatchV1().CronJobs("default").Update(context.TODO(), updatedCJ, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update cronjob: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeCronJob {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeCronJob)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestCronJobIngester_OnDelete(t *testing.T) {
+	// Create initial cronjob
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cronjob",
+			Namespace: "default",
+			UID:       "cj-uid-123",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/5 * * * *",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(cj)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the cronjob
+	err := clientset.BatchV1().CronJobs("default").Delete(context.TODO(), "test-cronjob", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete cronjob: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeCronJob {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeCronJob)
+		}
+		if event.Name != "test-cronjob" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-cronjob")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestCronJobIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a cronjob - this should not block even though channel is full
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cronjob",
+			Namespace: "default",
+			UID:       "cj-uid-123",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/5 * * * *",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.BatchV1().CronJobs("default").Create(context.TODO(), cj, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestCronJobIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial cronjob
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cronjob",
+			Namespace:       "default",
+			UID:             "cj-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/5 * * * *",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(cj)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(cj, cj)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}

--- a/internal/ingestion/job_ingester.go
+++ b/internal/ingestion/job_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// JobIngester watches Job resources and sends events to the event channel.
+type JobIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewJobIngester creates a new JobIngester.
+func NewJobIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *JobIngester {
+	return &JobIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("job-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (j *JobIngester) RegisterHandlers() {
+	informer := j.informerFactory.Batch().V1().Jobs().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    j.onAdd,
+		UpdateFunc: j.onUpdate,
+		DeleteFunc: j.onDelete,
+	})
+	if err != nil {
+		j.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles Job addition events.
+func (j *JobIngester) onAdd(obj interface{}) {
+	job, ok := obj.(*batchv1.Job)
+	if !ok {
+		j.log.Error(nil, "received non-Job object in add handler")
+		return
+	}
+
+	j.log.V(2).Info("job added",
+		"name", job.Name,
+		"namespace", job.Namespace,
+		"uid", job.UID)
+
+	j.sendEvent(transport.EventTypeAdded, job)
+}
+
+// onUpdate handles Job update events.
+func (j *JobIngester) onUpdate(oldObj, newObj interface{}) {
+	oldJob, ok := oldObj.(*batchv1.Job)
+	if !ok {
+		return
+	}
+	newJob, ok := newObj.(*batchv1.Job)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldJob.ResourceVersion == newJob.ResourceVersion {
+		return
+	}
+
+	j.log.V(2).Info("job updated",
+		"name", newJob.Name,
+		"namespace", newJob.Namespace,
+		"uid", newJob.UID)
+
+	j.sendEvent(transport.EventTypeUpdated, newJob)
+}
+
+// onDelete handles Job deletion events.
+func (j *JobIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	job, ok := obj.(*batchv1.Job)
+	if !ok {
+		j.log.Error(nil, "received non-Job object in delete handler")
+		return
+	}
+
+	j.log.V(2).Info("job deleted",
+		"name", job.Name,
+		"namespace", job.Namespace,
+		"uid", job.UID)
+
+	// For delete events, we only need identifying info, not full object
+	j.sendDeleteEvent(job)
+}
+
+// sendEvent sends a Job event to the event channel.
+func (j *JobIngester) sendEvent(eventType transport.EventType, job *batchv1.Job) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeJob,
+		UID:       string(job.UID),
+		Name:      job.Name,
+		Namespace: job.Namespace,
+		Object:    transport.NewJobInfo(job),
+	}
+
+	select {
+	case j.config.EventChan <- event:
+	default:
+		j.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", job.Name,
+			"namespace", job.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a Job delete event (without full object data).
+func (j *JobIngester) sendDeleteEvent(job *batchv1.Job) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeJob,
+		UID:       string(job.UID),
+		Name:      job.Name,
+		Namespace: job.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case j.config.EventChan <- event:
+	default:
+		j.log.Error(nil, "event channel full, dropping delete event",
+			"name", job.Name,
+			"namespace", job.Namespace)
+	}
+}

--- a/internal/ingestion/job_ingester_test.go
+++ b/internal/ingestion/job_ingester_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestJobIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a job
+	completions := int32(3)
+	parallelism := int32(2)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+			UID:       "job-uid-123",
+		},
+		Spec: batchv1.JobSpec{
+			Completions: &completions,
+			Parallelism: &parallelism,
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: 1,
+			Failed:    0,
+			Active:    2,
+		},
+	}
+
+	_, err := clientset.BatchV1().Jobs("default").Create(context.TODO(), job, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create job: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeJob {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeJob)
+		}
+		if event.Name != "test-job" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-job")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "job-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "job-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify JobInfo data
+		jobInfo, ok := event.Object.(transport.JobInfo)
+		if !ok {
+			t.Errorf("Object is not JobInfo: %T", event.Object)
+		} else {
+			if jobInfo.Completions != 3 {
+				t.Errorf("Completions = %d, want 3", jobInfo.Completions)
+			}
+			if jobInfo.Parallelism != 2 {
+				t.Errorf("Parallelism = %d, want 2", jobInfo.Parallelism)
+			}
+			if jobInfo.Succeeded != 1 {
+				t.Errorf("Succeeded = %d, want 1", jobInfo.Succeeded)
+			}
+			if jobInfo.Active != 2 {
+				t.Errorf("Active = %d, want 2", jobInfo.Active)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestJobIngester_OnUpdate(t *testing.T) {
+	// Create initial job
+	completions := int32(3)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-job",
+			Namespace:       "default",
+			UID:             "job-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: batchv1.JobSpec{
+			Completions: &completions,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(job)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the job
+	updatedJob := job.DeepCopy()
+	updatedJob.ResourceVersion = "2"
+	updatedJob.Status.Succeeded = 2
+
+	_, err := clientset.BatchV1().Jobs("default").Update(context.TODO(), updatedJob, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update job: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeJob {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeJob)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestJobIngester_OnDelete(t *testing.T) {
+	// Create initial job
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+			UID:       "job-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(job)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the job
+	err := clientset.BatchV1().Jobs("default").Delete(context.TODO(), "test-job", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete job: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeJob {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeJob)
+		}
+		if event.Name != "test-job" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-job")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestJobIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a job - this should not block even though channel is full
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+			UID:       "job-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.BatchV1().Jobs("default").Create(context.TODO(), job, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestJobIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial job
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-job",
+			Namespace:       "default",
+			UID:             "job-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(job)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(job, job)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}


### PR DESCRIPTION
## Summary

- Add `JobInfo` and `CronJobInfo` structs to transport/types.go with helper functions
- Create `job_ingester.go` following the established ingester pattern
- Create `cronjob_ingester.go` following the established ingester pattern
- Update `manager.go` to include jobIngester and cronjobIngester
- Add RBAC permissions for `batch` API group (jobs, cronjobs) in clusterrole.yaml
- Add comprehensive unit tests achieving 78.7% coverage for ingestion, 92.9% for transport

## Test plan

- [x] All existing tests pass
- [x] New JobIngester tests pass (OnAdd, OnUpdate, OnDelete, ChannelFull, SkipSameResourceVersion)
- [x] New CronJobIngester tests pass (OnAdd, OnUpdate, OnDelete, ChannelFull, SkipSameResourceVersion)
- [x] NewJobInfo and NewCronJobInfo helper tests pass
- [x] Race detection passes (`go test -race`)

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)