### PR TITLE
[GH-63] feat: add Ingress and NetworkPolicy ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Kubernetes operator that connects your cluster to the [Obsyk](https://obsyk.ai) 
 ## Features
 
 - **Deploy & Forget** - Single Custom Resource configures everything
-- **Real-time Sync** - Stream Namespace, Pod, and Service changes as they happen
+- **Real-time Sync** - Stream changes to Namespaces, Pods, Services, Nodes, Deployments, StatefulSets, DaemonSets, Ingresses, and NetworkPolicies as they happen
 - **Secure by Design** - Read-only cluster access, OAuth2 JWT authentication
 - **Lightweight** - Minimal resource footprint, efficient event-driven architecture
 
@@ -140,11 +140,17 @@ The operator uses **OAuth2 JWT Bearer** authentication (RFC 7523):
 
 The operator requires **read-only** access to cluster resources:
 
-| Resource | Verbs |
-|----------|-------|
-| Namespaces | list, watch |
-| Pods | list, watch |
-| Services | list, watch |
+| Resource | API Group | Verbs |
+|----------|-----------|-------|
+| Namespaces | core | list, watch |
+| Pods | core | list, watch |
+| Services | core | list, watch |
+| Nodes | core | list, watch |
+| Deployments | apps | list, watch |
+| StatefulSets | apps | list, watch |
+| DaemonSets | apps | list, watch |
+| Ingresses | networking.k8s.io | list, watch |
+| NetworkPolicies | networking.k8s.io | list, watch |
 
 ### Credential Security
 
@@ -236,6 +242,12 @@ status:
     namespaces: 10
     pods: 100
     services: 20
+    nodes: 5
+    deployments: 30
+    statefulsets: 5
+    daemonsets: 8
+    ingresses: 15
+    networkPolicies: 12
 ```
 
 ### Logs

--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -96,6 +96,20 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
   # Note: Secret access is granted via Role (namespace-scoped) for least privilege
   # See role.yaml for secret access in the operator namespace only
   # Leader election

--- a/internal/ingestion/ingress_ingester.go
+++ b/internal/ingestion/ingress_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// IngressIngester watches Ingress resources and sends events to the event channel.
+type IngressIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewIngressIngester creates a new IngressIngester.
+func NewIngressIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *IngressIngester {
+	return &IngressIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("ingress-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (i *IngressIngester) RegisterHandlers() {
+	informer := i.informerFactory.Networking().V1().Ingresses().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    i.onAdd,
+		UpdateFunc: i.onUpdate,
+		DeleteFunc: i.onDelete,
+	})
+	if err != nil {
+		i.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles Ingress addition events.
+func (i *IngressIngester) onAdd(obj interface{}) {
+	ing, ok := obj.(*networkingv1.Ingress)
+	if !ok {
+		i.log.Error(nil, "received non-Ingress object in add handler")
+		return
+	}
+
+	i.log.V(2).Info("ingress added",
+		"name", ing.Name,
+		"namespace", ing.Namespace,
+		"uid", ing.UID)
+
+	i.sendEvent(transport.EventTypeAdded, ing)
+}
+
+// onUpdate handles Ingress update events.
+func (i *IngressIngester) onUpdate(oldObj, newObj interface{}) {
+	oldIng, ok := oldObj.(*networkingv1.Ingress)
+	if !ok {
+		return
+	}
+	newIng, ok := newObj.(*networkingv1.Ingress)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldIng.ResourceVersion == newIng.ResourceVersion {
+		return
+	}
+
+	i.log.V(2).Info("ingress updated",
+		"name", newIng.Name,
+		"namespace", newIng.Namespace,
+		"uid", newIng.UID)
+
+	i.sendEvent(transport.EventTypeUpdated, newIng)
+}
+
+// onDelete handles Ingress deletion events.
+func (i *IngressIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	ing, ok := obj.(*networkingv1.Ingress)
+	if !ok {
+		i.log.Error(nil, "received non-Ingress object in delete handler")
+		return
+	}
+
+	i.log.V(2).Info("ingress deleted",
+		"name", ing.Name,
+		"namespace", ing.Namespace,
+		"uid", ing.UID)
+
+	// For delete events, we only need identifying info, not full object
+	i.sendDeleteEvent(ing)
+}
+
+// sendEvent sends an Ingress event to the event channel.
+func (i *IngressIngester) sendEvent(eventType transport.EventType, ing *networkingv1.Ingress) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeIngress,
+		UID:       string(ing.UID),
+		Name:      ing.Name,
+		Namespace: ing.Namespace,
+		Object:    transport.NewIngressInfo(ing),
+	}
+
+	select {
+	case i.config.EventChan <- event:
+	default:
+		i.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", ing.Name,
+			"namespace", ing.Namespace)
+	}
+}
+
+// sendDeleteEvent sends an Ingress delete event (without full object data).
+func (i *IngressIngester) sendDeleteEvent(ing *networkingv1.Ingress) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeIngress,
+		UID:       string(ing.UID),
+		Name:      ing.Name,
+		Namespace: ing.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case i.config.EventChan <- event:
+	default:
+		i.log.Error(nil, "event channel full, dropping delete event",
+			"name", ing.Name,
+			"namespace", ing.Namespace)
+	}
+}

--- a/internal/ingestion/ingress_ingester_test.go
+++ b/internal/ingestion/ingress_ingester_test.go
@@ -1,0 +1,344 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestIngressIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create an ingress
+	pathType := networkingv1.PathTypePrefix
+	ingressClassName := "nginx"
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ingress",
+			Namespace: "default",
+			UID:       "ing-uid-123",
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingressClassName,
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/api",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "api-service",
+											Port: networkingv1.ServiceBackendPort{
+												Number: 8080,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			TLS: []networkingv1.IngressTLS{
+				{
+					Hosts:      []string{"example.com"},
+					SecretName: "tls-secret",
+				},
+			},
+		},
+	}
+
+	_, err := clientset.NetworkingV1().Ingresses("default").Create(context.TODO(), ing, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create ingress: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeIngress {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeIngress)
+		}
+		if event.Name != "test-ingress" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-ingress")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "ing-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "ing-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify IngressInfo data
+		ingInfo, ok := event.Object.(transport.IngressInfo)
+		if !ok {
+			t.Errorf("Object is not IngressInfo: %T", event.Object)
+		} else {
+			if ingInfo.IngressClassName != "nginx" {
+				t.Errorf("IngressClassName = %s, want nginx", ingInfo.IngressClassName)
+			}
+			if len(ingInfo.Rules) != 1 {
+				t.Errorf("Rules count = %d, want 1", len(ingInfo.Rules))
+			} else if ingInfo.Rules[0].Host != "example.com" {
+				t.Errorf("Rules[0].Host = %s, want example.com", ingInfo.Rules[0].Host)
+			}
+			if len(ingInfo.TLS) != 1 {
+				t.Errorf("TLS count = %d, want 1", len(ingInfo.TLS))
+			} else if ingInfo.TLS[0].SecretName != "tls-secret" {
+				t.Errorf("TLS[0].SecretName = %s, want tls-secret", ingInfo.TLS[0].SecretName)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestIngressIngester_OnUpdate(t *testing.T) {
+	// Create initial ingress
+	pathType := networkingv1.PathTypePrefix
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-ingress",
+			Namespace:       "default",
+			UID:             "ing-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/api",
+									PathType: &pathType,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(ing)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the ingress
+	updatedIng := ing.DeepCopy()
+	updatedIng.ResourceVersion = "2"
+	updatedIng.Spec.Rules[0].Host = "updated.example.com"
+
+	_, err := clientset.NetworkingV1().Ingresses("default").Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update ingress: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeIngress {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeIngress)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestIngressIngester_OnDelete(t *testing.T) {
+	// Create initial ingress
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ingress",
+			Namespace: "default",
+			UID:       "ing-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(ing)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the ingress
+	err := clientset.NetworkingV1().Ingresses("default").Delete(context.TODO(), "test-ingress", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete ingress: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeIngress {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeIngress)
+		}
+		if event.Name != "test-ingress" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-ingress")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestIngressIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create an ingress - this should not block even though channel is full
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ingress",
+			Namespace: "default",
+			UID:       "ing-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.NetworkingV1().Ingresses("default").Create(context.TODO(), ing, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestIngressIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial ingress
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-ingress",
+			Namespace:       "default",
+			UID:             "ing-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(ing)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(ing, ing)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}

--- a/internal/ingestion/networkpolicy_ingester.go
+++ b/internal/ingestion/networkpolicy_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NetworkPolicyIngester watches NetworkPolicy resources and sends events to the event channel.
+type NetworkPolicyIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewNetworkPolicyIngester creates a new NetworkPolicyIngester.
+func NewNetworkPolicyIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *NetworkPolicyIngester {
+	return &NetworkPolicyIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("networkpolicy-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (n *NetworkPolicyIngester) RegisterHandlers() {
+	informer := n.informerFactory.Networking().V1().NetworkPolicies().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    n.onAdd,
+		UpdateFunc: n.onUpdate,
+		DeleteFunc: n.onDelete,
+	})
+	if err != nil {
+		n.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles NetworkPolicy addition events.
+func (n *NetworkPolicyIngester) onAdd(obj interface{}) {
+	np, ok := obj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		n.log.Error(nil, "received non-NetworkPolicy object in add handler")
+		return
+	}
+
+	n.log.V(2).Info("networkpolicy added",
+		"name", np.Name,
+		"namespace", np.Namespace,
+		"uid", np.UID)
+
+	n.sendEvent(transport.EventTypeAdded, np)
+}
+
+// onUpdate handles NetworkPolicy update events.
+func (n *NetworkPolicyIngester) onUpdate(oldObj, newObj interface{}) {
+	oldNP, ok := oldObj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return
+	}
+	newNP, ok := newObj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldNP.ResourceVersion == newNP.ResourceVersion {
+		return
+	}
+
+	n.log.V(2).Info("networkpolicy updated",
+		"name", newNP.Name,
+		"namespace", newNP.Namespace,
+		"uid", newNP.UID)
+
+	n.sendEvent(transport.EventTypeUpdated, newNP)
+}
+
+// onDelete handles NetworkPolicy deletion events.
+func (n *NetworkPolicyIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	np, ok := obj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		n.log.Error(nil, "received non-NetworkPolicy object in delete handler")
+		return
+	}
+
+	n.log.V(2).Info("networkpolicy deleted",
+		"name", np.Name,
+		"namespace", np.Namespace,
+		"uid", np.UID)
+
+	// For delete events, we only need identifying info, not full object
+	n.sendDeleteEvent(np)
+}
+
+// sendEvent sends a NetworkPolicy event to the event channel.
+func (n *NetworkPolicyIngester) sendEvent(eventType transport.EventType, np *networkingv1.NetworkPolicy) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeNetworkPolicy,
+		UID:       string(np.UID),
+		Name:      np.Name,
+		Namespace: np.Namespace,
+		Object:    transport.NewNetworkPolicyInfo(np),
+	}
+
+	select {
+	case n.config.EventChan <- event:
+	default:
+		n.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", np.Name,
+			"namespace", np.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a NetworkPolicy delete event (without full object data).
+func (n *NetworkPolicyIngester) sendDeleteEvent(np *networkingv1.NetworkPolicy) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeNetworkPolicy,
+		UID:       string(np.UID),
+		Name:      np.Name,
+		Namespace: np.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case n.config.EventChan <- event:
+	default:
+		n.log.Error(nil, "event channel full, dropping delete event",
+			"name", np.Name,
+			"namespace", np.Namespace)
+	}
+}

--- a/internal/ingestion/networkpolicy_ingester_test.go
+++ b/internal/ingestion/networkpolicy_ingester_test.go
@@ -1,0 +1,349 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestNetworkPolicyIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a network policy
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-netpol",
+			Namespace: "default",
+			UID:       "np-uid-123",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "web",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "frontend",
+								},
+							},
+						},
+					},
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "database",
+								},
+							},
+						},
+					},
+				},
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "cache",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := clientset.NetworkingV1().NetworkPolicies("default").Create(context.TODO(), np, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create network policy: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeNetworkPolicy {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeNetworkPolicy)
+		}
+		if event.Name != "test-netpol" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-netpol")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "np-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "np-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify NetworkPolicyInfo data
+		npInfo, ok := event.Object.(transport.NetworkPolicyInfo)
+		if !ok {
+			t.Errorf("Object is not NetworkPolicyInfo: %T", event.Object)
+		} else {
+			if npInfo.PodSelector["app"] != "web" {
+				t.Errorf("PodSelector[app] = %s, want web", npInfo.PodSelector["app"])
+			}
+			if len(npInfo.PolicyTypes) != 2 {
+				t.Errorf("PolicyTypes count = %d, want 2", len(npInfo.PolicyTypes))
+			}
+			if npInfo.IngressRules != 1 {
+				t.Errorf("IngressRules = %d, want 1", npInfo.IngressRules)
+			}
+			if npInfo.EgressRules != 2 {
+				t.Errorf("EgressRules = %d, want 2", npInfo.EgressRules)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestNetworkPolicyIngester_OnUpdate(t *testing.T) {
+	// Create initial network policy
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-netpol",
+			Namespace:       "default",
+			UID:             "np-uid-123",
+			ResourceVersion: "1",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "web",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(np)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the network policy
+	updatedNP := np.DeepCopy()
+	updatedNP.ResourceVersion = "2"
+	updatedNP.Spec.PolicyTypes = append(updatedNP.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)
+
+	_, err := clientset.NetworkingV1().NetworkPolicies("default").Update(context.TODO(), updatedNP, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update network policy: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeNetworkPolicy {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeNetworkPolicy)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestNetworkPolicyIngester_OnDelete(t *testing.T) {
+	// Create initial network policy
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-netpol",
+			Namespace: "default",
+			UID:       "np-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(np)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the network policy
+	err := clientset.NetworkingV1().NetworkPolicies("default").Delete(context.TODO(), "test-netpol", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete network policy: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeNetworkPolicy {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeNetworkPolicy)
+		}
+		if event.Name != "test-netpol" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-netpol")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestNetworkPolicyIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a network policy - this should not block even though channel is full
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-netpol",
+			Namespace: "default",
+			UID:       "np-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.NetworkingV1().NetworkPolicies("default").Create(context.TODO(), np, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestNetworkPolicyIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial network policy
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-netpol",
+			Namespace:       "default",
+			UID:             "np-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(np)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(np, np)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}


### PR DESCRIPTION
## Summary

- Add `IngressInfo` and `NetworkPolicyInfo` structs to transport/types.go with helper functions
- Create `ingress_ingester.go` following the established ingester pattern
- Create `networkpolicy_ingester.go` following the established ingester pattern
- Update `manager.go` to include ingressIngester and networkpolicyIngester
- Add RBAC permissions for `networking.k8s.io` API group (ingresses, networkpolicies) in clusterrole.yaml
- Add comprehensive unit tests achieving 78.7% coverage for ingestion, 93.1% for transport
- Update CLAUDE.md with new ingesters documentation
- Update README.md with expanded resource list and RBAC permissions

### IngressInfo captures:
- Name, namespace, UID, labels, annotations
- Ingress class name
- Rules (hosts, paths with service backends)
- TLS configuration (hosts, secret names)
- Load balancer IPs/hostnames

### NetworkPolicyInfo captures:
- Name, namespace, UID, labels, annotations
- Pod selector
- Policy types (Ingress/Egress)
- Ingress and egress rule counts

## Test plan

- [x] All existing tests pass
- [x] New IngressIngester tests pass (OnAdd, OnUpdate, OnDelete, ChannelFull, SkipSameResourceVersion)
- [x] New NetworkPolicyIngester tests pass (OnAdd, OnUpdate, OnDelete, ChannelFull, SkipSameResourceVersion)
- [x] NewIngressInfo and NewNetworkPolicyInfo helper tests pass
- [x] Race detection passes (`go test -race`)

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)