### PR TITLE
[GH-65] feat: add PersistentVolumeClaim ingestion

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -127,6 +127,13 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - list
+      - watch
   # Leader election
   - apiGroups:
       - coordination.k8s.io

--- a/internal/ingestion/pvc_ingester.go
+++ b/internal/ingestion/pvc_ingester.go
@@ -1,0 +1,147 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// PVCIngester watches PersistentVolumeClaim resources and sends events to the event channel.
+type PVCIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewPVCIngester creates a new PVCIngester.
+func NewPVCIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *PVCIngester {
+	return &PVCIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("pvc-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (i *PVCIngester) RegisterHandlers() {
+	informer := i.informerFactory.Core().V1().PersistentVolumeClaims().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    i.onAdd,
+		UpdateFunc: i.onUpdate,
+		DeleteFunc: i.onDelete,
+	})
+	if err != nil {
+		i.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles PVC addition events.
+func (i *PVCIngester) onAdd(obj interface{}) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		i.log.Error(nil, "received non-PVC object in add handler")
+		return
+	}
+
+	i.log.V(2).Info("pvc added",
+		"name", pvc.Name,
+		"namespace", pvc.Namespace,
+		"uid", pvc.UID)
+
+	i.sendEvent(transport.EventTypeAdded, pvc)
+}
+
+// onUpdate handles PVC update events.
+func (i *PVCIngester) onUpdate(oldObj, newObj interface{}) {
+	oldPVC, ok := oldObj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return
+	}
+	newPVC, ok := newObj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldPVC.ResourceVersion == newPVC.ResourceVersion {
+		return
+	}
+
+	i.log.V(2).Info("pvc updated",
+		"name", newPVC.Name,
+		"namespace", newPVC.Namespace,
+		"uid", newPVC.UID,
+		"phase", newPVC.Status.Phase)
+
+	i.sendEvent(transport.EventTypeUpdated, newPVC)
+}
+
+// onDelete handles PVC deletion events.
+func (i *PVCIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		i.log.Error(nil, "received non-PVC object in delete handler")
+		return
+	}
+
+	i.log.V(2).Info("pvc deleted",
+		"name", pvc.Name,
+		"namespace", pvc.Namespace,
+		"uid", pvc.UID)
+
+	// For delete events, we only need identifying info, not full object
+	i.sendDeleteEvent(pvc)
+}
+
+// sendEvent sends a PVC event to the event channel.
+func (i *PVCIngester) sendEvent(eventType transport.EventType, pvc *corev1.PersistentVolumeClaim) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypePersistentVolumeClaim,
+		UID:       string(pvc.UID),
+		Name:      pvc.Name,
+		Namespace: pvc.Namespace,
+		Object:    transport.NewPVCInfo(pvc),
+	}
+
+	select {
+	case i.config.EventChan <- event:
+	default:
+		i.log.Info("event channel full, dropping PVC event",
+			"type", eventType,
+			"name", pvc.Name,
+			"namespace", pvc.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a PVC delete event (without full object data).
+func (i *PVCIngester) sendDeleteEvent(pvc *corev1.PersistentVolumeClaim) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypePersistentVolumeClaim,
+		UID:       string(pvc.UID),
+		Name:      pvc.Name,
+		Namespace: pvc.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case i.config.EventChan <- event:
+	default:
+		i.log.Info("event channel full, dropping PVC delete event",
+			"name", pvc.Name,
+			"namespace", pvc.Namespace)
+	}
+}

--- a/internal/ingestion/pvc_ingester_test.go
+++ b/internal/ingestion/pvc_ingester_test.go
@@ -1,0 +1,448 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestPVCIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a PVC
+	storageClass := "fast-ssd"
+	volumeMode := corev1.PersistentVolumeFilesystem
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			UID:       "pvc-uid-123",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			VolumeMode:       &volumeMode,
+			VolumeName:       "pv-123",
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	}
+
+	_, err := clientset.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create PVC: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypePersistentVolumeClaim {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypePersistentVolumeClaim)
+		}
+		if event.Name != "test-pvc" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-pvc")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.UID != "pvc-uid-123" {
+			t.Errorf("UID = %v, want %v", event.UID, "pvc-uid-123")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		// Verify PVCInfo data
+		pvcInfo, ok := event.Object.(transport.PVCInfo)
+		if !ok {
+			t.Errorf("Object is not PVCInfo: %T", event.Object)
+		} else {
+			if pvcInfo.StorageClassName != "fast-ssd" {
+				t.Errorf("StorageClassName = %s, want fast-ssd", pvcInfo.StorageClassName)
+			}
+			if len(pvcInfo.AccessModes) != 1 || pvcInfo.AccessModes[0] != "ReadWriteOnce" {
+				t.Errorf("AccessModes = %v, want [ReadWriteOnce]", pvcInfo.AccessModes)
+			}
+			if pvcInfo.StorageRequest != "10Gi" {
+				t.Errorf("StorageRequest = %s, want 10Gi", pvcInfo.StorageRequest)
+			}
+			if pvcInfo.VolumeName != "pv-123" {
+				t.Errorf("VolumeName = %s, want pv-123", pvcInfo.VolumeName)
+			}
+			if pvcInfo.VolumeMode != "Filesystem" {
+				t.Errorf("VolumeMode = %s, want Filesystem", pvcInfo.VolumeMode)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestPVCIngester_OnUpdate(t *testing.T) {
+	// Create initial PVC
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pvc",
+			Namespace:       "default",
+			UID:             "pvc-uid-123",
+			ResourceVersion: "1",
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(pvc)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the PVC
+	updatedPVC := pvc.DeepCopy()
+	updatedPVC.ResourceVersion = "2"
+	updatedPVC.Spec.VolumeName = "pv-123"
+	updatedPVC.Status.Phase = corev1.ClaimBound
+
+	_, err := clientset.CoreV1().PersistentVolumeClaims("default").Update(context.TODO(), updatedPVC, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update PVC: %v", err)
+	}
+
+	// Wait for update event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypePersistentVolumeClaim {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypePersistentVolumeClaim)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for update event")
+		}
+		// Verify updated data
+		pvcInfo, ok := event.Object.(transport.PVCInfo)
+		if !ok {
+			t.Errorf("Object is not PVCInfo: %T", event.Object)
+		} else {
+			if pvcInfo.Phase != "Bound" {
+				t.Errorf("Phase = %s, want Bound", pvcInfo.Phase)
+			}
+			if pvcInfo.VolumeName != "pv-123" {
+				t.Errorf("VolumeName = %s, want pv-123", pvcInfo.VolumeName)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestPVCIngester_OnDelete(t *testing.T) {
+	// Create initial PVC
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			UID:       "pvc-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(pvc)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the PVC
+	err := clientset.CoreV1().PersistentVolumeClaims("default").Delete(context.TODO(), "test-pvc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete PVC: %v", err)
+	}
+
+	// Wait for delete event
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypePersistentVolumeClaim {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypePersistentVolumeClaim)
+		}
+		if event.Name != "test-pvc" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-pvc")
+		}
+		// Object should be nil for delete events
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestPVCIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// Create a channel with capacity 0 to simulate full channel
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Create a PVC - this should not block even though channel is full
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			UID:       "pvc-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	// Should complete without blocking
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestPVCIngester_SkipSameResourceVersion(t *testing.T) {
+	// Create initial PVC
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pvc",
+			Namespace:       "default",
+			UID:             "pvc-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(pvc)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(pvc, pvc)
+
+	// Should not receive any event
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}
+
+func TestPVCIngester_PVCPhases(t *testing.T) {
+	testCases := []struct {
+		name     string
+		phase    corev1.PersistentVolumeClaimPhase
+		expected string
+	}{
+		{
+			name:     "Pending",
+			phase:    corev1.ClaimPending,
+			expected: "Pending",
+		},
+		{
+			name:     "Bound",
+			phase:    corev1.ClaimBound,
+			expected: "Bound",
+		},
+		{
+			name:     "Lost",
+			phase:    corev1.ClaimLost,
+			expected: "Lost",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			factory := informers.NewSharedInformerFactory(clientset, 0)
+			eventChan := make(chan ResourceEvent, 10)
+			log := ctrl.Log.WithName("test")
+
+			ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+			ingester.RegisterHandlers()
+
+			// Start informer
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			factory.Start(stopCh)
+			factory.WaitForCacheSync(stopCh)
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc-" + tc.name,
+					Namespace: "default",
+					UID:       types.UID("pvc-uid-" + tc.name),
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Phase: tc.phase,
+				},
+			}
+
+			_, err := clientset.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("failed to create PVC: %v", err)
+			}
+
+			select {
+			case event := <-eventChan:
+				pvcInfo, ok := event.Object.(transport.PVCInfo)
+				if !ok {
+					t.Fatal("Object is not PVCInfo")
+				}
+				if pvcInfo.Phase != tc.expected {
+					t.Errorf("Phase = %s, want %s", pvcInfo.Phase, tc.expected)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for event")
+			}
+		})
+	}
+}
+
+func TestPVCIngester_AccessModes(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			UID:       "pvc-uid-123",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+				corev1.ReadOnlyMany,
+			},
+		},
+	}
+
+	_, err := clientset.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create PVC: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		pvcInfo, ok := event.Object.(transport.PVCInfo)
+		if !ok {
+			t.Fatal("Object is not PVCInfo")
+		}
+		if len(pvcInfo.AccessModes) != 2 {
+			t.Errorf("AccessModes count = %d, want 2", len(pvcInfo.AccessModes))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `PVCInfo` struct with storage class, access modes, storage request, volume name, phase, and volume mode
- Create `PVCIngester` with add/update/delete event handlers following the established pattern
- Add `ResourceTypePersistentVolumeClaim` constant
- Update `SnapshotPayload` and `ResourceCounts` to include PVCs
- Add RBAC permissions for `list`/`watch` on `persistentvolumeclaims`
- Add comprehensive tests for all PVC phases (Pending, Bound, Lost) and access modes

## Test plan
- [x] Unit tests for `PVCIngester` OnAdd/OnUpdate/OnDelete handlers
- [x] Tests for channel full scenarios (non-blocking behavior)
- [x] Tests for skipping duplicate updates (same ResourceVersion)
- [x] Tests for all PVC phases (Pending, Bound, Lost)
- [x] Tests for multiple access modes
- [x] Tests for `NewPVCInfo()` helper function
- [x] All tests passing locally

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)