### PR TITLE
[GH-66] feat: add RBAC resource collection for KSPM visibility

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -134,6 +134,43 @@ rules:
     verbs:
       - list
       - watch
+  # ServiceAccount collection for KSPM/RBAC visibility
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # RBAC resource collection for security posture assessment
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - list
+      - watch
   # Leader election
   - apiGroups:
       - coordination.k8s.io

--- a/internal/ingestion/clusterrole_ingester.go
+++ b/internal/ingestion/clusterrole_ingester.go
@@ -1,0 +1,141 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ClusterRoleIngester watches ClusterRole resources and sends events to the event channel.
+type ClusterRoleIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewClusterRoleIngester creates a new ClusterRoleIngester.
+func NewClusterRoleIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *ClusterRoleIngester {
+	return &ClusterRoleIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("clusterrole-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (c *ClusterRoleIngester) RegisterHandlers() {
+	informer := c.informerFactory.Rbac().V1().ClusterRoles().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onAdd,
+		UpdateFunc: c.onUpdate,
+		DeleteFunc: c.onDelete,
+	})
+	if err != nil {
+		c.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles ClusterRole addition events.
+func (c *ClusterRoleIngester) onAdd(obj interface{}) {
+	clusterRole, ok := obj.(*rbacv1.ClusterRole)
+	if !ok {
+		c.log.Error(nil, "received non-ClusterRole object in add handler")
+		return
+	}
+
+	c.log.V(2).Info("clusterrole added",
+		"name", clusterRole.Name,
+		"uid", clusterRole.UID)
+
+	c.sendEvent(transport.EventTypeAdded, clusterRole)
+}
+
+// onUpdate handles ClusterRole update events.
+func (c *ClusterRoleIngester) onUpdate(oldObj, newObj interface{}) {
+	oldClusterRole, ok := oldObj.(*rbacv1.ClusterRole)
+	if !ok {
+		return
+	}
+	newClusterRole, ok := newObj.(*rbacv1.ClusterRole)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldClusterRole.ResourceVersion == newClusterRole.ResourceVersion {
+		return
+	}
+
+	c.log.V(2).Info("clusterrole updated",
+		"name", newClusterRole.Name,
+		"uid", newClusterRole.UID)
+
+	c.sendEvent(transport.EventTypeUpdated, newClusterRole)
+}
+
+// onDelete handles ClusterRole deletion events.
+func (c *ClusterRoleIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	clusterRole, ok := obj.(*rbacv1.ClusterRole)
+	if !ok {
+		c.log.Error(nil, "received non-ClusterRole object in delete handler")
+		return
+	}
+
+	c.log.V(2).Info("clusterrole deleted",
+		"name", clusterRole.Name,
+		"uid", clusterRole.UID)
+
+	// For delete events, we only need identifying info, not full object
+	c.sendDeleteEvent(clusterRole)
+}
+
+// sendEvent sends a ClusterRole event to the event channel.
+func (c *ClusterRoleIngester) sendEvent(eventType transport.EventType, clusterRole *rbacv1.ClusterRole) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeClusterRole,
+		UID:       string(clusterRole.UID),
+		Name:      clusterRole.Name,
+		Namespace: "", // ClusterRole is cluster-scoped
+		Object:    transport.NewClusterRoleInfo(clusterRole),
+	}
+
+	select {
+	case c.config.EventChan <- event:
+	default:
+		c.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", clusterRole.Name)
+	}
+}
+
+// sendDeleteEvent sends a ClusterRole delete event (without full object data).
+func (c *ClusterRoleIngester) sendDeleteEvent(clusterRole *rbacv1.ClusterRole) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeClusterRole,
+		UID:       string(clusterRole.UID),
+		Name:      clusterRole.Name,
+		Namespace: "",  // ClusterRole is cluster-scoped
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case c.config.EventChan <- event:
+	default:
+		c.log.Error(nil, "event channel full, dropping delete event",
+			"name", clusterRole.Name)
+	}
+}

--- a/internal/ingestion/clusterrole_ingester_test.go
+++ b/internal/ingestion/clusterrole_ingester_test.go
@@ -1,0 +1,280 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestClusterRoleIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-clusterrole",
+			UID:    "cr-uid-123",
+			Labels: map[string]string{"app": "test"},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes", "namespaces"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments", "statefulsets"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+
+	_, err := clientset.RbacV1().ClusterRoles().Create(context.Background(), clusterRole, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create clusterrole: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeClusterRole {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRole)
+		}
+		if event.Name != "test-clusterrole" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-clusterrole")
+		}
+		if event.Namespace != "" {
+			t.Errorf("Namespace = %v, want empty string for cluster-scoped resource", event.Namespace)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		roleInfo, ok := event.Object.(transport.RoleInfo)
+		if !ok {
+			t.Errorf("Object is not RoleInfo: %T", event.Object)
+		} else {
+			if roleInfo.RuleCount != 2 {
+				t.Errorf("RuleCount = %d, want 2", roleInfo.RuleCount)
+			}
+			if !roleInfo.IsCluster {
+				t.Error("IsCluster should be true for ClusterRole")
+			}
+			if len(roleInfo.Resources) != 4 {
+				t.Errorf("Resources count = %d, want 4", len(roleInfo.Resources))
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestClusterRoleIngester_OnUpdate(t *testing.T) {
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-clusterrole",
+			UID:             "cr-uid-123",
+			ResourceVersion: "1",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(clusterRole)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the clusterrole
+	updatedCR := clusterRole.DeepCopy()
+	updatedCR.ResourceVersion = "2"
+	updatedCR.Rules = append(updatedCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"apps"},
+		Resources: []string{"deployments"},
+		Verbs:     []string{"get", "list"},
+	})
+
+	_, err := clientset.RbacV1().ClusterRoles().Update(context.Background(), updatedCR, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update clusterrole: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeClusterRole {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRole)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestClusterRoleIngester_OnDelete(t *testing.T) {
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusterrole",
+			UID:  "cr-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(clusterRole)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the clusterrole
+	err := clientset.RbacV1().ClusterRoles().Delete(context.Background(), "test-clusterrole", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete clusterrole: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeClusterRole {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRole)
+		}
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestClusterRoleIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusterrole",
+			UID:  "cr-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.RbacV1().ClusterRoles().Create(context.Background(), clusterRole, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestClusterRoleIngester_SkipSameResourceVersion(t *testing.T) {
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-clusterrole",
+			UID:             "cr-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(clusterRole)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(clusterRole, clusterRole)
+
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}

--- a/internal/ingestion/clusterrolebinding_ingester.go
+++ b/internal/ingestion/clusterrolebinding_ingester.go
@@ -1,0 +1,141 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ClusterRoleBindingIngester watches ClusterRoleBinding resources and sends events to the event channel.
+type ClusterRoleBindingIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewClusterRoleBindingIngester creates a new ClusterRoleBindingIngester.
+func NewClusterRoleBindingIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *ClusterRoleBindingIngester {
+	return &ClusterRoleBindingIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("clusterrolebinding-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (c *ClusterRoleBindingIngester) RegisterHandlers() {
+	informer := c.informerFactory.Rbac().V1().ClusterRoleBindings().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onAdd,
+		UpdateFunc: c.onUpdate,
+		DeleteFunc: c.onDelete,
+	})
+	if err != nil {
+		c.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles ClusterRoleBinding addition events.
+func (c *ClusterRoleBindingIngester) onAdd(obj interface{}) {
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		c.log.Error(nil, "received non-ClusterRoleBinding object in add handler")
+		return
+	}
+
+	c.log.V(2).Info("clusterrolebinding added",
+		"name", crb.Name,
+		"uid", crb.UID)
+
+	c.sendEvent(transport.EventTypeAdded, crb)
+}
+
+// onUpdate handles ClusterRoleBinding update events.
+func (c *ClusterRoleBindingIngester) onUpdate(oldObj, newObj interface{}) {
+	oldCRB, ok := oldObj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		return
+	}
+	newCRB, ok := newObj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldCRB.ResourceVersion == newCRB.ResourceVersion {
+		return
+	}
+
+	c.log.V(2).Info("clusterrolebinding updated",
+		"name", newCRB.Name,
+		"uid", newCRB.UID)
+
+	c.sendEvent(transport.EventTypeUpdated, newCRB)
+}
+
+// onDelete handles ClusterRoleBinding deletion events.
+func (c *ClusterRoleBindingIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		c.log.Error(nil, "received non-ClusterRoleBinding object in delete handler")
+		return
+	}
+
+	c.log.V(2).Info("clusterrolebinding deleted",
+		"name", crb.Name,
+		"uid", crb.UID)
+
+	// For delete events, we only need identifying info, not full object
+	c.sendDeleteEvent(crb)
+}
+
+// sendEvent sends a ClusterRoleBinding event to the event channel.
+func (c *ClusterRoleBindingIngester) sendEvent(eventType transport.EventType, crb *rbacv1.ClusterRoleBinding) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeClusterRoleBinding,
+		UID:       string(crb.UID),
+		Name:      crb.Name,
+		Namespace: "", // ClusterRoleBinding is cluster-scoped
+		Object:    transport.NewClusterRoleBindingInfo(crb),
+	}
+
+	select {
+	case c.config.EventChan <- event:
+	default:
+		c.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", crb.Name)
+	}
+}
+
+// sendDeleteEvent sends a ClusterRoleBinding delete event (without full object data).
+func (c *ClusterRoleBindingIngester) sendDeleteEvent(crb *rbacv1.ClusterRoleBinding) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeClusterRoleBinding,
+		UID:       string(crb.UID),
+		Name:      crb.Name,
+		Namespace: "",  // ClusterRoleBinding is cluster-scoped
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case c.config.EventChan <- event:
+	default:
+		c.log.Error(nil, "event channel full, dropping delete event",
+			"name", crb.Name)
+	}
+}

--- a/internal/ingestion/clusterrolebinding_ingester_test.go
+++ b/internal/ingestion/clusterrolebinding_ingester_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestClusterRoleBindingIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-clusterrolebinding",
+			UID:    "crb-uid-123",
+			Labels: map[string]string{"app": "test"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "admin-sa",
+				Namespace: "kube-system",
+			},
+			{
+				Kind: "Group",
+				Name: "system:masters",
+			},
+		},
+	}
+
+	_, err := clientset.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create clusterrolebinding: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeClusterRoleBinding {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRoleBinding)
+		}
+		if event.Name != "test-clusterrolebinding" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-clusterrolebinding")
+		}
+		if event.Namespace != "" {
+			t.Errorf("Namespace = %v, want empty string for cluster-scoped resource", event.Namespace)
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		rbInfo, ok := event.Object.(transport.RoleBindingInfo)
+		if !ok {
+			t.Errorf("Object is not RoleBindingInfo: %T", event.Object)
+		} else {
+			if rbInfo.RoleRef.Kind != "ClusterRole" {
+				t.Errorf("RoleRef.Kind = %s, want ClusterRole", rbInfo.RoleRef.Kind)
+			}
+			if rbInfo.RoleRef.Name != "cluster-admin" {
+				t.Errorf("RoleRef.Name = %s, want cluster-admin", rbInfo.RoleRef.Name)
+			}
+			if len(rbInfo.Subjects) != 2 {
+				t.Errorf("Subjects count = %d, want 2", len(rbInfo.Subjects))
+			}
+			if !rbInfo.IsCluster {
+				t.Error("IsCluster should be true for ClusterRoleBinding")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestClusterRoleBindingIngester_OnUpdate(t *testing.T) {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-clusterrolebinding",
+			UID:             "crb-uid-123",
+			ResourceVersion: "1",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "admin-sa",
+				Namespace: "kube-system",
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(crb)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the clusterrolebinding
+	updatedCRB := crb.DeepCopy()
+	updatedCRB.ResourceVersion = "2"
+	updatedCRB.Subjects = append(updatedCRB.Subjects, rbacv1.Subject{
+		Kind: "User",
+		Name: "newadmin",
+	})
+
+	_, err := clientset.RbacV1().ClusterRoleBindings().Update(context.Background(), updatedCRB, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update clusterrolebinding: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeClusterRoleBinding {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRoleBinding)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestClusterRoleBindingIngester_OnDelete(t *testing.T) {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusterrolebinding",
+			UID:  "crb-uid-123",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "cluster-admin",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(crb)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the clusterrolebinding
+	err := clientset.RbacV1().ClusterRoleBindings().Delete(context.Background(), "test-clusterrolebinding", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete clusterrolebinding: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeClusterRoleBinding {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRoleBinding)
+		}
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestClusterRoleBindingIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusterrolebinding",
+			UID:  "crb-uid-123",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "cluster-admin",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestClusterRoleBindingIngester_SkipSameResourceVersion(t *testing.T) {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-clusterrolebinding",
+			UID:             "crb-uid-123",
+			ResourceVersion: "1",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "cluster-admin",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(crb)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(crb, crb)
+
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}

--- a/internal/ingestion/role_ingester.go
+++ b/internal/ingestion/role_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// RoleIngester watches Role resources and sends events to the event channel.
+type RoleIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewRoleIngester creates a new RoleIngester.
+func NewRoleIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *RoleIngester {
+	return &RoleIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("role-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (r *RoleIngester) RegisterHandlers() {
+	informer := r.informerFactory.Rbac().V1().Roles().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    r.onAdd,
+		UpdateFunc: r.onUpdate,
+		DeleteFunc: r.onDelete,
+	})
+	if err != nil {
+		r.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles Role addition events.
+func (r *RoleIngester) onAdd(obj interface{}) {
+	role, ok := obj.(*rbacv1.Role)
+	if !ok {
+		r.log.Error(nil, "received non-Role object in add handler")
+		return
+	}
+
+	r.log.V(2).Info("role added",
+		"name", role.Name,
+		"namespace", role.Namespace,
+		"uid", role.UID)
+
+	r.sendEvent(transport.EventTypeAdded, role)
+}
+
+// onUpdate handles Role update events.
+func (r *RoleIngester) onUpdate(oldObj, newObj interface{}) {
+	oldRole, ok := oldObj.(*rbacv1.Role)
+	if !ok {
+		return
+	}
+	newRole, ok := newObj.(*rbacv1.Role)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldRole.ResourceVersion == newRole.ResourceVersion {
+		return
+	}
+
+	r.log.V(2).Info("role updated",
+		"name", newRole.Name,
+		"namespace", newRole.Namespace,
+		"uid", newRole.UID)
+
+	r.sendEvent(transport.EventTypeUpdated, newRole)
+}
+
+// onDelete handles Role deletion events.
+func (r *RoleIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	role, ok := obj.(*rbacv1.Role)
+	if !ok {
+		r.log.Error(nil, "received non-Role object in delete handler")
+		return
+	}
+
+	r.log.V(2).Info("role deleted",
+		"name", role.Name,
+		"namespace", role.Namespace,
+		"uid", role.UID)
+
+	// For delete events, we only need identifying info, not full object
+	r.sendDeleteEvent(role)
+}
+
+// sendEvent sends a Role event to the event channel.
+func (r *RoleIngester) sendEvent(eventType transport.EventType, role *rbacv1.Role) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeRole,
+		UID:       string(role.UID),
+		Name:      role.Name,
+		Namespace: role.Namespace,
+		Object:    transport.NewRoleInfo(role),
+	}
+
+	select {
+	case r.config.EventChan <- event:
+	default:
+		r.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", role.Name,
+			"namespace", role.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a Role delete event (without full object data).
+func (r *RoleIngester) sendDeleteEvent(role *rbacv1.Role) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeRole,
+		UID:       string(role.UID),
+		Name:      role.Name,
+		Namespace: role.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case r.config.EventChan <- event:
+	default:
+		r.log.Error(nil, "event channel full, dropping delete event",
+			"name", role.Name,
+			"namespace", role.Namespace)
+	}
+}

--- a/internal/ingestion/role_ingester_test.go
+++ b/internal/ingestion/role_ingester_test.go
@@ -1,0 +1,285 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestRoleIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: "default",
+			UID:       "role-uid-123",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+
+	_, err := clientset.RbacV1().Roles("default").Create(context.Background(), role, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create role: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeRole {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRole)
+		}
+		if event.Name != "test-role" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-role")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		roleInfo, ok := event.Object.(transport.RoleInfo)
+		if !ok {
+			t.Errorf("Object is not RoleInfo: %T", event.Object)
+		} else {
+			if roleInfo.RuleCount != 2 {
+				t.Errorf("RuleCount = %d, want 2", roleInfo.RuleCount)
+			}
+			if roleInfo.IsCluster {
+				t.Error("IsCluster should be false for Role")
+			}
+			if len(roleInfo.Resources) != 3 {
+				t.Errorf("Resources count = %d, want 3", len(roleInfo.Resources))
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestRoleIngester_OnUpdate(t *testing.T) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-role",
+			Namespace:       "default",
+			UID:             "role-uid-123",
+			ResourceVersion: "1",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(role)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the role
+	updatedRole := role.DeepCopy()
+	updatedRole.ResourceVersion = "2"
+	updatedRole.Rules = append(updatedRole.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"apps"},
+		Resources: []string{"deployments"},
+		Verbs:     []string{"get", "list"},
+	})
+
+	_, err := clientset.RbacV1().Roles("default").Update(context.Background(), updatedRole, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update role: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeRole {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRole)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestRoleIngester_OnDelete(t *testing.T) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: "default",
+			UID:       "role-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(role)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the role
+	err := clientset.RbacV1().Roles("default").Delete(context.Background(), "test-role", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete role: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeRole {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRole)
+		}
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestRoleIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: "default",
+			UID:       "role-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.RbacV1().Roles("default").Create(context.Background(), role, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestRoleIngester_SkipSameResourceVersion(t *testing.T) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-role",
+			Namespace:       "default",
+			UID:             "role-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(role)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(role, role)
+
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}

--- a/internal/ingestion/rolebinding_ingester.go
+++ b/internal/ingestion/rolebinding_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// RoleBindingIngester watches RoleBinding resources and sends events to the event channel.
+type RoleBindingIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewRoleBindingIngester creates a new RoleBindingIngester.
+func NewRoleBindingIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *RoleBindingIngester {
+	return &RoleBindingIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("rolebinding-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (r *RoleBindingIngester) RegisterHandlers() {
+	informer := r.informerFactory.Rbac().V1().RoleBindings().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    r.onAdd,
+		UpdateFunc: r.onUpdate,
+		DeleteFunc: r.onDelete,
+	})
+	if err != nil {
+		r.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles RoleBinding addition events.
+func (r *RoleBindingIngester) onAdd(obj interface{}) {
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok {
+		r.log.Error(nil, "received non-RoleBinding object in add handler")
+		return
+	}
+
+	r.log.V(2).Info("rolebinding added",
+		"name", rb.Name,
+		"namespace", rb.Namespace,
+		"uid", rb.UID)
+
+	r.sendEvent(transport.EventTypeAdded, rb)
+}
+
+// onUpdate handles RoleBinding update events.
+func (r *RoleBindingIngester) onUpdate(oldObj, newObj interface{}) {
+	oldRB, ok := oldObj.(*rbacv1.RoleBinding)
+	if !ok {
+		return
+	}
+	newRB, ok := newObj.(*rbacv1.RoleBinding)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldRB.ResourceVersion == newRB.ResourceVersion {
+		return
+	}
+
+	r.log.V(2).Info("rolebinding updated",
+		"name", newRB.Name,
+		"namespace", newRB.Namespace,
+		"uid", newRB.UID)
+
+	r.sendEvent(transport.EventTypeUpdated, newRB)
+}
+
+// onDelete handles RoleBinding deletion events.
+func (r *RoleBindingIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok {
+		r.log.Error(nil, "received non-RoleBinding object in delete handler")
+		return
+	}
+
+	r.log.V(2).Info("rolebinding deleted",
+		"name", rb.Name,
+		"namespace", rb.Namespace,
+		"uid", rb.UID)
+
+	// For delete events, we only need identifying info, not full object
+	r.sendDeleteEvent(rb)
+}
+
+// sendEvent sends a RoleBinding event to the event channel.
+func (r *RoleBindingIngester) sendEvent(eventType transport.EventType, rb *rbacv1.RoleBinding) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeRoleBinding,
+		UID:       string(rb.UID),
+		Name:      rb.Name,
+		Namespace: rb.Namespace,
+		Object:    transport.NewRoleBindingInfo(rb),
+	}
+
+	select {
+	case r.config.EventChan <- event:
+	default:
+		r.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", rb.Name,
+			"namespace", rb.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a RoleBinding delete event (without full object data).
+func (r *RoleBindingIngester) sendDeleteEvent(rb *rbacv1.RoleBinding) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeRoleBinding,
+		UID:       string(rb.UID),
+		Name:      rb.Name,
+		Namespace: rb.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case r.config.EventChan <- event:
+	default:
+		r.log.Error(nil, "event channel full, dropping delete event",
+			"name", rb.Name,
+			"namespace", rb.Namespace)
+	}
+}

--- a/internal/ingestion/rolebinding_ingester_test.go
+++ b/internal/ingestion/rolebinding_ingester_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestRoleBindingIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "default",
+			UID:       "rb-uid-123",
+			Labels:    map[string]string{"app": "test"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: "default",
+			},
+			{
+				Kind: "User",
+				Name: "jane",
+			},
+		},
+	}
+
+	_, err := clientset.RbacV1().RoleBindings("default").Create(context.Background(), rb, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create rolebinding: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeRoleBinding {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRoleBinding)
+		}
+		if event.Name != "test-rolebinding" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-rolebinding")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		rbInfo, ok := event.Object.(transport.RoleBindingInfo)
+		if !ok {
+			t.Errorf("Object is not RoleBindingInfo: %T", event.Object)
+		} else {
+			if rbInfo.RoleRef.Kind != "Role" {
+				t.Errorf("RoleRef.Kind = %s, want Role", rbInfo.RoleRef.Kind)
+			}
+			if rbInfo.RoleRef.Name != "test-role" {
+				t.Errorf("RoleRef.Name = %s, want test-role", rbInfo.RoleRef.Name)
+			}
+			if len(rbInfo.Subjects) != 2 {
+				t.Errorf("Subjects count = %d, want 2", len(rbInfo.Subjects))
+			}
+			if rbInfo.IsCluster {
+				t.Error("IsCluster should be false for RoleBinding")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestRoleBindingIngester_OnUpdate(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-rolebinding",
+			Namespace:       "default",
+			UID:             "rb-uid-123",
+			ResourceVersion: "1",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: "default",
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(rb)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the rolebinding
+	updatedRB := rb.DeepCopy()
+	updatedRB.ResourceVersion = "2"
+	updatedRB.Subjects = append(updatedRB.Subjects, rbacv1.Subject{
+		Kind: "User",
+		Name: "newuser",
+	})
+
+	_, err := clientset.RbacV1().RoleBindings("default").Update(context.Background(), updatedRB, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update rolebinding: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeRoleBinding {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRoleBinding)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestRoleBindingIngester_OnDelete(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "default",
+			UID:       "rb-uid-123",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: "test-role",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(rb)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the rolebinding
+	err := clientset.RbacV1().RoleBindings("default").Delete(context.Background(), "test-rolebinding", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete rolebinding: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeRoleBinding {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRoleBinding)
+		}
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestRoleBindingIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "default",
+			UID:       "rb-uid-123",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: "test-role",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.RbacV1().RoleBindings("default").Create(context.Background(), rb, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestRoleBindingIngester_SkipSameResourceVersion(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-rolebinding",
+			Namespace:       "default",
+			UID:             "rb-uid-123",
+			ResourceVersion: "1",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: "test-role",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(rb)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(rb, rb)
+
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}

--- a/internal/ingestion/serviceaccount_ingester.go
+++ b/internal/ingestion/serviceaccount_ingester.go
@@ -1,0 +1,146 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ServiceAccountIngester watches ServiceAccount resources and sends events to the event channel.
+type ServiceAccountIngester struct {
+	informerFactory informers.SharedInformerFactory
+	config          IngesterConfig
+	log             logr.Logger
+}
+
+// NewServiceAccountIngester creates a new ServiceAccountIngester.
+func NewServiceAccountIngester(factory informers.SharedInformerFactory, cfg IngesterConfig, log logr.Logger) *ServiceAccountIngester {
+	return &ServiceAccountIngester{
+		informerFactory: factory,
+		config:          cfg,
+		log:             log.WithName("serviceaccount-ingester"),
+	}
+}
+
+// RegisterHandlers registers the event handlers with the informer.
+// This must be called before starting the informer factory.
+func (s *ServiceAccountIngester) RegisterHandlers() {
+	informer := s.informerFactory.Core().V1().ServiceAccounts().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    s.onAdd,
+		UpdateFunc: s.onUpdate,
+		DeleteFunc: s.onDelete,
+	})
+	if err != nil {
+		s.log.Error(err, "failed to add event handler")
+	}
+}
+
+// onAdd handles ServiceAccount addition events.
+func (s *ServiceAccountIngester) onAdd(obj interface{}) {
+	sa, ok := obj.(*corev1.ServiceAccount)
+	if !ok {
+		s.log.Error(nil, "received non-ServiceAccount object in add handler")
+		return
+	}
+
+	s.log.V(2).Info("serviceaccount added",
+		"name", sa.Name,
+		"namespace", sa.Namespace,
+		"uid", sa.UID)
+
+	s.sendEvent(transport.EventTypeAdded, sa)
+}
+
+// onUpdate handles ServiceAccount update events.
+func (s *ServiceAccountIngester) onUpdate(oldObj, newObj interface{}) {
+	oldSA, ok := oldObj.(*corev1.ServiceAccount)
+	if !ok {
+		return
+	}
+	newSA, ok := newObj.(*corev1.ServiceAccount)
+	if !ok {
+		return
+	}
+
+	// Skip if resource version hasn't changed (no actual update)
+	if oldSA.ResourceVersion == newSA.ResourceVersion {
+		return
+	}
+
+	s.log.V(2).Info("serviceaccount updated",
+		"name", newSA.Name,
+		"namespace", newSA.Namespace,
+		"uid", newSA.UID)
+
+	s.sendEvent(transport.EventTypeUpdated, newSA)
+}
+
+// onDelete handles ServiceAccount deletion events.
+func (s *ServiceAccountIngester) onDelete(obj interface{}) {
+	// Handle DeletedFinalStateUnknown (object was deleted from cache before we saw the delete event)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	sa, ok := obj.(*corev1.ServiceAccount)
+	if !ok {
+		s.log.Error(nil, "received non-ServiceAccount object in delete handler")
+		return
+	}
+
+	s.log.V(2).Info("serviceaccount deleted",
+		"name", sa.Name,
+		"namespace", sa.Namespace,
+		"uid", sa.UID)
+
+	// For delete events, we only need identifying info, not full object
+	s.sendDeleteEvent(sa)
+}
+
+// sendEvent sends a ServiceAccount event to the event channel.
+func (s *ServiceAccountIngester) sendEvent(eventType transport.EventType, sa *corev1.ServiceAccount) {
+	event := ResourceEvent{
+		Type:      eventType,
+		Kind:      transport.ResourceTypeServiceAccount,
+		UID:       string(sa.UID),
+		Name:      sa.Name,
+		Namespace: sa.Namespace,
+		Object:    transport.NewServiceAccountInfo(sa),
+	}
+
+	select {
+	case s.config.EventChan <- event:
+	default:
+		s.log.Error(nil, "event channel full, dropping event",
+			"type", eventType,
+			"name", sa.Name,
+			"namespace", sa.Namespace)
+	}
+}
+
+// sendDeleteEvent sends a ServiceAccount delete event (without full object data).
+func (s *ServiceAccountIngester) sendDeleteEvent(sa *corev1.ServiceAccount) {
+	event := ResourceEvent{
+		Type:      transport.EventTypeDeleted,
+		Kind:      transport.ResourceTypeServiceAccount,
+		UID:       string(sa.UID),
+		Name:      sa.Name,
+		Namespace: sa.Namespace,
+		Object:    nil, // No object data for deletes
+	}
+
+	select {
+	case s.config.EventChan <- event:
+	default:
+		s.log.Error(nil, "event channel full, dropping delete event",
+			"name", sa.Name,
+			"namespace", sa.Namespace)
+	}
+}

--- a/internal/ingestion/serviceaccount_ingester_test.go
+++ b/internal/ingestion/serviceaccount_ingester_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) Obsyk. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsyk/obsyk-operator/internal/transport"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestServiceAccountIngester_OnAdd(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	// Start informer
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	automount := true
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sa",
+			Namespace: "default",
+			UID:       "sa-uid-123",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Secrets: []corev1.ObjectReference{
+			{Name: "sa-token-secret"},
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "docker-registry"},
+		},
+		AutomountServiceAccountToken: &automount,
+	}
+
+	_, err := clientset.CoreV1().ServiceAccounts("default").Create(context.Background(), sa, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create serviceaccount: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeAdded {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeAdded)
+		}
+		if event.Kind != transport.ResourceTypeServiceAccount {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeServiceAccount)
+		}
+		if event.Name != "test-sa" {
+			t.Errorf("Name = %v, want %v", event.Name, "test-sa")
+		}
+		if event.Namespace != "default" {
+			t.Errorf("Namespace = %v, want %v", event.Namespace, "default")
+		}
+		if event.Object == nil {
+			t.Error("Object should not be nil for add event")
+		}
+		saInfo, ok := event.Object.(transport.ServiceAccountInfo)
+		if !ok {
+			t.Errorf("Object is not ServiceAccountInfo: %T", event.Object)
+		} else {
+			if len(saInfo.Secrets) != 1 {
+				t.Errorf("Secrets count = %d, want 1", len(saInfo.Secrets))
+			}
+			if len(saInfo.ImagePullSecrets) != 1 {
+				t.Errorf("ImagePullSecrets count = %d, want 1", len(saInfo.ImagePullSecrets))
+			}
+			if saInfo.AutomountServiceAccountToken == nil || !*saInfo.AutomountServiceAccountToken {
+				t.Error("AutomountServiceAccountToken should be true")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for add event")
+	}
+}
+
+func TestServiceAccountIngester_OnUpdate(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-sa",
+			Namespace:       "default",
+			UID:             "sa-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(sa)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Update the serviceaccount
+	updatedSA := sa.DeepCopy()
+	updatedSA.ResourceVersion = "2"
+	updatedSA.Labels = map[string]string{"updated": "true"}
+
+	_, err := clientset.CoreV1().ServiceAccounts("default").Update(context.Background(), updatedSA, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update serviceaccount: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeUpdated {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		}
+		if event.Kind != transport.ResourceTypeServiceAccount {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeServiceAccount)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for update event")
+	}
+}
+
+func TestServiceAccountIngester_OnDelete(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sa",
+			Namespace: "default",
+			UID:       "sa-uid-123",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(sa)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Delete the serviceaccount
+	err := clientset.CoreV1().ServiceAccounts("default").Delete(context.Background(), "test-sa", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete serviceaccount: %v", err)
+	}
+
+	select {
+	case event := <-eventChan:
+		if event.Type != transport.EventTypeDeleted {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeDeleted)
+		}
+		if event.Kind != transport.ResourceTypeServiceAccount {
+			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeServiceAccount)
+		}
+		if event.Object != nil {
+			t.Error("Object should be nil for delete event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for delete event")
+	}
+}
+
+func TestServiceAccountIngester_ChannelFull(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sa",
+			Namespace: "default",
+			UID:       "sa-uid-123",
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = clientset.CoreV1().ServiceAccounts("default").Create(context.Background(), sa, metav1.CreateOptions{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - event was dropped but didn't block
+	case <-time.After(2 * time.Second):
+		t.Error("create operation blocked when channel was full")
+	}
+}
+
+func TestServiceAccountIngester_SkipSameResourceVersion(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-sa",
+			Namespace:       "default",
+			UID:             "sa-uid-123",
+			ResourceVersion: "1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(sa)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	eventChan := make(chan ResourceEvent, 10)
+	log := ctrl.Log.WithName("test")
+
+	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
+	ingester.RegisterHandlers()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	// Drain initial add event
+	select {
+	case <-eventChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial add event")
+	}
+
+	// Manually call onUpdate with same resource version - should be skipped
+	ingester.onUpdate(sa, sa)
+
+	select {
+	case event := <-eventChan:
+		t.Errorf("should not receive event for same resource version, got: %+v", event)
+	case <-time.After(100 * time.Millisecond):
+		// Success - no event was sent
+	}
+}


### PR DESCRIPTION
## Summary
- Add collection of ServiceAccount, Role, ClusterRole, RoleBinding, and ClusterRoleBinding resources
- Support KSPM (Kubernetes Security Posture Management) visibility on the platform
- 5 new ingesters following existing patterns with comprehensive test coverage

## Changes
- **transport/types.go**: Add `ServiceAccountInfo`, `RoleInfo`, `RoleBindingInfo` structs with supporting types `RoleRef` and `Subject`
- **New ingesters**: 
  - `serviceaccount_ingester.go` - watches ServiceAccounts
  - `role_ingester.go` - watches Roles
  - `clusterrole_ingester.go` - watches ClusterRoles
  - `rolebinding_ingester.go` - watches RoleBindings
  - `clusterrolebinding_ingester.go` - watches ClusterRoleBindings
- **manager.go**: Register new ingesters and add GetCurrentState support for RBAC resources
- **clusterrole.yaml**: Add list/watch permissions for all RBAC resource types

## Test plan
- [x] Unit tests for all 5 new ingesters (OnAdd, OnUpdate, OnDelete, ChannelFull, SkipSameResourceVersion)
- [x] All existing tests still pass
- [x] CI pipeline passes (`make ci`)

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)