### PR TITLE
[GH-81] fix: align event type constants with platform expectations

### DIFF
--- a/internal/ingestion/clusterrole_ingester.go
+++ b/internal/ingestion/clusterrole_ingester.go
@@ -77,7 +77,7 @@ func (c *ClusterRoleIngester) onUpdate(oldObj, newObj interface{}) {
 		"name", newClusterRole.Name,
 		"uid", newClusterRole.UID)
 
-	c.sendEvent(transport.EventTypeUpdated, newClusterRole)
+	c.sendEvent(transport.EventTypeModified, newClusterRole)
 }
 
 // onDelete handles ClusterRole deletion events.

--- a/internal/ingestion/clusterrole_ingester_test.go
+++ b/internal/ingestion/clusterrole_ingester_test.go
@@ -143,8 +143,8 @@ func TestClusterRoleIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeClusterRole {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRole)

--- a/internal/ingestion/clusterrolebinding_ingester.go
+++ b/internal/ingestion/clusterrolebinding_ingester.go
@@ -77,7 +77,7 @@ func (c *ClusterRoleBindingIngester) onUpdate(oldObj, newObj interface{}) {
 		"name", newCRB.Name,
 		"uid", newCRB.UID)
 
-	c.sendEvent(transport.EventTypeUpdated, newCRB)
+	c.sendEvent(transport.EventTypeModified, newCRB)
 }
 
 // onDelete handles ClusterRoleBinding deletion events.

--- a/internal/ingestion/clusterrolebinding_ingester_test.go
+++ b/internal/ingestion/clusterrolebinding_ingester_test.go
@@ -154,8 +154,8 @@ func TestClusterRoleBindingIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeClusterRoleBinding {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeClusterRoleBinding)

--- a/internal/ingestion/configmap_ingester.go
+++ b/internal/ingestion/configmap_ingester.go
@@ -75,7 +75,7 @@ func (i *ConfigMapIngester) onUpdate(oldObj, newObj interface{}) {
 	i.lastVersion[key] = cm.ResourceVersion
 
 	i.log.V(1).Info("ConfigMap updated", "name", cm.Name, "namespace", cm.Namespace)
-	i.sendEvent(transport.EventTypeUpdated, cm)
+	i.sendEvent(transport.EventTypeModified, cm)
 }
 
 // onDelete handles ConfigMap delete events.

--- a/internal/ingestion/configmap_ingester_test.go
+++ b/internal/ingestion/configmap_ingester_test.go
@@ -120,7 +120,7 @@ func TestConfigMapIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
+		if event.Type != transport.EventTypeModified {
 			t.Errorf("Type = %s, want UPDATED", event.Type)
 		}
 		if event.Kind != transport.ResourceTypeConfigMap {

--- a/internal/ingestion/cronjob_ingester.go
+++ b/internal/ingestion/cronjob_ingester.go
@@ -79,7 +79,7 @@ func (c *CronJobIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newCJ.Namespace,
 		"uid", newCJ.UID)
 
-	c.sendEvent(transport.EventTypeUpdated, newCJ)
+	c.sendEvent(transport.EventTypeModified, newCJ)
 }
 
 // onDelete handles CronJob deletion events.

--- a/internal/ingestion/cronjob_ingester_test.go
+++ b/internal/ingestion/cronjob_ingester_test.go
@@ -143,8 +143,8 @@ func TestCronJobIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeCronJob {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeCronJob)

--- a/internal/ingestion/daemonset_ingester.go
+++ b/internal/ingestion/daemonset_ingester.go
@@ -79,7 +79,7 @@ func (d *DaemonSetIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newDs.Namespace,
 		"uid", newDs.UID)
 
-	d.sendEvent(transport.EventTypeUpdated, newDs)
+	d.sendEvent(transport.EventTypeModified, newDs)
 }
 
 // onDelete handles DaemonSet deletion events.

--- a/internal/ingestion/daemonset_ingester_test.go
+++ b/internal/ingestion/daemonset_ingester_test.go
@@ -178,8 +178,8 @@ func TestDaemonSetIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeDaemonSet {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeDaemonSet)

--- a/internal/ingestion/deployment_ingester.go
+++ b/internal/ingestion/deployment_ingester.go
@@ -79,7 +79,7 @@ func (d *DeploymentIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newDeploy.Namespace,
 		"uid", newDeploy.UID)
 
-	d.sendEvent(transport.EventTypeUpdated, newDeploy)
+	d.sendEvent(transport.EventTypeModified, newDeploy)
 }
 
 // onDelete handles Deployment deletion events.

--- a/internal/ingestion/deployment_ingester_test.go
+++ b/internal/ingestion/deployment_ingester_test.go
@@ -175,8 +175,8 @@ func TestDeploymentIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeDeployment {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeDeployment)

--- a/internal/ingestion/event_ingester.go
+++ b/internal/ingestion/event_ingester.go
@@ -82,7 +82,7 @@ func (e *EventIngester) onUpdate(oldObj, newObj interface{}) {
 		"reason", newEvent.Reason,
 		"count", newEvent.Count)
 
-	e.sendEvent(transport.EventTypeUpdated, newEvent)
+	e.sendEvent(transport.EventTypeModified, newEvent)
 }
 
 // onDelete handles Event deletion events.

--- a/internal/ingestion/event_ingester_test.go
+++ b/internal/ingestion/event_ingester_test.go
@@ -155,8 +155,8 @@ func TestEventIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeEvent {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeEvent)

--- a/internal/ingestion/ingress_ingester.go
+++ b/internal/ingestion/ingress_ingester.go
@@ -79,7 +79,7 @@ func (i *IngressIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newIng.Namespace,
 		"uid", newIng.UID)
 
-	i.sendEvent(transport.EventTypeUpdated, newIng)
+	i.sendEvent(transport.EventTypeModified, newIng)
 }
 
 // onDelete handles Ingress deletion events.

--- a/internal/ingestion/ingress_ingester_test.go
+++ b/internal/ingestion/ingress_ingester_test.go
@@ -187,8 +187,8 @@ func TestIngressIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeIngress {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeIngress)

--- a/internal/ingestion/integration_test.go
+++ b/internal/ingestion/integration_test.go
@@ -193,7 +193,7 @@ func TestIntegration_UpdateDeleteFlow(t *testing.T) {
 	events := sender.getEvents()
 	foundUpdate := false
 	for _, event := range events {
-		if event.Type == string(transport.EventTypeUpdated) && event.Kind == string(transport.ResourceTypePod) {
+		if event.Type == string(transport.EventTypeModified) && event.Kind == string(transport.ResourceTypePod) {
 			foundUpdate = true
 			break
 		}

--- a/internal/ingestion/job_ingester.go
+++ b/internal/ingestion/job_ingester.go
@@ -79,7 +79,7 @@ func (j *JobIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newJob.Namespace,
 		"uid", newJob.UID)
 
-	j.sendEvent(transport.EventTypeUpdated, newJob)
+	j.sendEvent(transport.EventTypeModified, newJob)
 }
 
 // onDelete handles Job deletion events.

--- a/internal/ingestion/job_ingester_test.go
+++ b/internal/ingestion/job_ingester_test.go
@@ -149,8 +149,8 @@ func TestJobIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeJob {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeJob)

--- a/internal/ingestion/namespace_ingester.go
+++ b/internal/ingestion/namespace_ingester.go
@@ -77,7 +77,7 @@ func (n *NamespaceIngester) onUpdate(oldObj, newObj interface{}) {
 		"name", newNS.Name,
 		"uid", newNS.UID)
 
-	n.sendEvent(transport.EventTypeUpdated, newNS)
+	n.sendEvent(transport.EventTypeModified, newNS)
 }
 
 // onDelete handles Namespace deletion events.

--- a/internal/ingestion/namespace_ingester_test.go
+++ b/internal/ingestion/namespace_ingester_test.go
@@ -112,8 +112,8 @@ func TestNamespaceIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeNamespace {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeNamespace)

--- a/internal/ingestion/networkpolicy_ingester.go
+++ b/internal/ingestion/networkpolicy_ingester.go
@@ -79,7 +79,7 @@ func (n *NetworkPolicyIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newNP.Namespace,
 		"uid", newNP.UID)
 
-	n.sendEvent(transport.EventTypeUpdated, newNP)
+	n.sendEvent(transport.EventTypeModified, newNP)
 }
 
 // onDelete handles NetworkPolicy deletion events.

--- a/internal/ingestion/networkpolicy_ingester_test.go
+++ b/internal/ingestion/networkpolicy_ingester_test.go
@@ -192,8 +192,8 @@ func TestNetworkPolicyIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeNetworkPolicy {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeNetworkPolicy)

--- a/internal/ingestion/node_ingester.go
+++ b/internal/ingestion/node_ingester.go
@@ -77,7 +77,7 @@ func (n *NodeIngester) onUpdate(oldObj, newObj interface{}) {
 		"name", newNode.Name,
 		"uid", newNode.UID)
 
-	n.sendEvent(transport.EventTypeUpdated, newNode)
+	n.sendEvent(transport.EventTypeModified, newNode)
 }
 
 // onDelete handles Node deletion events.

--- a/internal/ingestion/node_ingester_test.go
+++ b/internal/ingestion/node_ingester_test.go
@@ -157,8 +157,8 @@ func TestNodeIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeNode {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeNode)

--- a/internal/ingestion/pod_ingester.go
+++ b/internal/ingestion/pod_ingester.go
@@ -79,7 +79,7 @@ func (p *PodIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newPod.Namespace,
 		"uid", newPod.UID)
 
-	p.sendEvent(transport.EventTypeUpdated, newPod)
+	p.sendEvent(transport.EventTypeModified, newPod)
 }
 
 // onDelete handles Pod deletion events.

--- a/internal/ingestion/pod_ingester_test.go
+++ b/internal/ingestion/pod_ingester_test.go
@@ -121,8 +121,8 @@ func TestPodIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypePod {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypePod)

--- a/internal/ingestion/pvc_ingester.go
+++ b/internal/ingestion/pvc_ingester.go
@@ -80,7 +80,7 @@ func (i *PVCIngester) onUpdate(oldObj, newObj interface{}) {
 		"uid", newPVC.UID,
 		"phase", newPVC.Status.Phase)
 
-	i.sendEvent(transport.EventTypeUpdated, newPVC)
+	i.sendEvent(transport.EventTypeModified, newPVC)
 }
 
 // onDelete handles PVC deletion events.

--- a/internal/ingestion/pvc_ingester_test.go
+++ b/internal/ingestion/pvc_ingester_test.go
@@ -160,8 +160,8 @@ func TestPVCIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypePersistentVolumeClaim {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypePersistentVolumeClaim)

--- a/internal/ingestion/role_ingester.go
+++ b/internal/ingestion/role_ingester.go
@@ -79,7 +79,7 @@ func (r *RoleIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newRole.Namespace,
 		"uid", newRole.UID)
 
-	r.sendEvent(transport.EventTypeUpdated, newRole)
+	r.sendEvent(transport.EventTypeModified, newRole)
 }
 
 // onDelete handles Role deletion events.

--- a/internal/ingestion/role_ingester_test.go
+++ b/internal/ingestion/role_ingester_test.go
@@ -145,8 +145,8 @@ func TestRoleIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeRole {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRole)

--- a/internal/ingestion/rolebinding_ingester.go
+++ b/internal/ingestion/rolebinding_ingester.go
@@ -79,7 +79,7 @@ func (r *RoleBindingIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newRB.Namespace,
 		"uid", newRB.UID)
 
-	r.sendEvent(transport.EventTypeUpdated, newRB)
+	r.sendEvent(transport.EventTypeModified, newRB)
 }
 
 // onDelete handles RoleBinding deletion events.

--- a/internal/ingestion/rolebinding_ingester_test.go
+++ b/internal/ingestion/rolebinding_ingester_test.go
@@ -156,8 +156,8 @@ func TestRoleBindingIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeRoleBinding {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeRoleBinding)

--- a/internal/ingestion/secret_ingester.go
+++ b/internal/ingestion/secret_ingester.go
@@ -81,7 +81,7 @@ func (i *SecretIngester) onUpdate(oldObj, newObj interface{}) {
 
 	// SECURITY: Never log secret data - only log metadata
 	i.log.V(1).Info("Secret updated", "name", secret.Name, "namespace", secret.Namespace, "type", secret.Type)
-	i.sendEvent(transport.EventTypeUpdated, secret)
+	i.sendEvent(transport.EventTypeModified, secret)
 }
 
 // onDelete handles Secret delete events.

--- a/internal/ingestion/secret_ingester_test.go
+++ b/internal/ingestion/secret_ingester_test.go
@@ -121,7 +121,7 @@ func TestSecretIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
+		if event.Type != transport.EventTypeModified {
 			t.Errorf("Type = %s, want UPDATED", event.Type)
 		}
 		if event.Kind != transport.ResourceTypeSecret {

--- a/internal/ingestion/service_ingester.go
+++ b/internal/ingestion/service_ingester.go
@@ -79,7 +79,7 @@ func (s *ServiceIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newSvc.Namespace,
 		"uid", newSvc.UID)
 
-	s.sendEvent(transport.EventTypeUpdated, newSvc)
+	s.sendEvent(transport.EventTypeModified, newSvc)
 }
 
 // onDelete handles Service deletion events.

--- a/internal/ingestion/service_ingester_test.go
+++ b/internal/ingestion/service_ingester_test.go
@@ -122,8 +122,8 @@ func TestServiceIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeService {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeService)

--- a/internal/ingestion/serviceaccount_ingester.go
+++ b/internal/ingestion/serviceaccount_ingester.go
@@ -79,7 +79,7 @@ func (s *ServiceAccountIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newSA.Namespace,
 		"uid", newSA.UID)
 
-	s.sendEvent(transport.EventTypeUpdated, newSA)
+	s.sendEvent(transport.EventTypeModified, newSA)
 }
 
 // onDelete handles ServiceAccount deletion events.

--- a/internal/ingestion/serviceaccount_ingester_test.go
+++ b/internal/ingestion/serviceaccount_ingester_test.go
@@ -131,8 +131,8 @@ func TestServiceAccountIngester_OnUpdate(t *testing.T) {
 
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeServiceAccount {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeServiceAccount)

--- a/internal/ingestion/statefulset_ingester.go
+++ b/internal/ingestion/statefulset_ingester.go
@@ -79,7 +79,7 @@ func (s *StatefulSetIngester) onUpdate(oldObj, newObj interface{}) {
 		"namespace", newSts.Namespace,
 		"uid", newSts.UID)
 
-	s.sendEvent(transport.EventTypeUpdated, newSts)
+	s.sendEvent(transport.EventTypeModified, newSts)
 }
 
 // onDelete handles StatefulSet deletion events.

--- a/internal/ingestion/statefulset_ingester_test.go
+++ b/internal/ingestion/statefulset_ingester_test.go
@@ -179,8 +179,8 @@ func TestStatefulSetIngester_OnUpdate(t *testing.T) {
 	// Wait for update event
 	select {
 	case event := <-eventChan:
-		if event.Type != transport.EventTypeUpdated {
-			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeUpdated)
+		if event.Type != transport.EventTypeModified {
+			t.Errorf("Type = %v, want %v", event.Type, transport.EventTypeModified)
 		}
 		if event.Kind != transport.ResourceTypeStatefulSet {
 			t.Errorf("Kind = %v, want %v", event.Kind, transport.ResourceTypeStatefulSet)

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -18,9 +18,9 @@ import (
 type EventType string
 
 const (
-	EventTypeAdded   EventType = "ADDED"
-	EventTypeUpdated EventType = "UPDATED"
-	EventTypeDeleted EventType = "DELETED"
+	EventTypeAdded    EventType = "added"
+	EventTypeModified EventType = "modified"
+	EventTypeDeleted  EventType = "deleted"
 )
 
 // ResourceType represents the type of Kubernetes resource.


### PR DESCRIPTION
## Summary
- Change event type constants to lowercase to match platform expectations
- Rename `EventTypeUpdated` to `EventTypeModified` to align with Kubernetes watch event conventions
- Update all ingesters and tests to use the new constant name

## Changes

### Before
```go
const (
    EventTypeAdded   EventType = "ADDED"
    EventTypeUpdated EventType = "UPDATED"
    EventTypeDeleted EventType = "DELETED"
)
```

### After
```go
const (
    EventTypeAdded    EventType = "added"
    EventTypeModified EventType = "modified"
    EventTypeDeleted  EventType = "deleted"
)
```

## Rationale
- Platform expects lowercase event types: `added`, `modified`, `deleted`
- Platform uses "modified" terminology (matching Kubernetes) rather than "updated"
- This eliminates case-insensitive handling and naming mapping on the platform side

## Files Changed
- `internal/transport/types.go` - Updated constant definitions
- All ingester files - Changed `EventTypeUpdated` → `EventTypeModified`
- All test files - Updated to use `EventTypeModified`

## Test plan
- [x] All ingestion tests pass
- [x] Integration tests pass
- [x] Code compiles cleanly
- [ ] CI passes

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)