### PR TITLE
[GH-88] feat: update CRD ResourceCounts to include all 20 resource types

### DIFF
--- a/api/v1/obsykagent_types.go
+++ b/api/v1/obsykagent_types.go
@@ -127,6 +127,57 @@ type ResourceCounts struct {
 
 	// Services is the count of services being watched.
 	Services int32 `json:"services,omitempty"`
+
+	// Nodes is the count of nodes being watched.
+	Nodes int32 `json:"nodes,omitempty"`
+
+	// Deployments is the count of deployments being watched.
+	Deployments int32 `json:"deployments,omitempty"`
+
+	// StatefulSets is the count of statefulsets being watched.
+	StatefulSets int32 `json:"statefulSets,omitempty"`
+
+	// DaemonSets is the count of daemonsets being watched.
+	DaemonSets int32 `json:"daemonSets,omitempty"`
+
+	// Jobs is the count of jobs being watched.
+	Jobs int32 `json:"jobs,omitempty"`
+
+	// CronJobs is the count of cronjobs being watched.
+	CronJobs int32 `json:"cronJobs,omitempty"`
+
+	// Ingresses is the count of ingresses being watched.
+	Ingresses int32 `json:"ingresses,omitempty"`
+
+	// NetworkPolicies is the count of network policies being watched.
+	NetworkPolicies int32 `json:"networkPolicies,omitempty"`
+
+	// ConfigMaps is the count of configmaps being watched.
+	ConfigMaps int32 `json:"configMaps,omitempty"`
+
+	// Secrets is the count of secrets being watched.
+	Secrets int32 `json:"secrets,omitempty"`
+
+	// PVCs is the count of persistent volume claims being watched.
+	PVCs int32 `json:"pvcs,omitempty"`
+
+	// ServiceAccounts is the count of service accounts being watched.
+	ServiceAccounts int32 `json:"serviceAccounts,omitempty"`
+
+	// Roles is the count of roles being watched.
+	Roles int32 `json:"roles,omitempty"`
+
+	// ClusterRoles is the count of cluster roles being watched.
+	ClusterRoles int32 `json:"clusterRoles,omitempty"`
+
+	// RoleBindings is the count of role bindings being watched.
+	RoleBindings int32 `json:"roleBindings,omitempty"`
+
+	// ClusterRoleBindings is the count of cluster role bindings being watched.
+	ClusterRoleBindings int32 `json:"clusterRoleBindings,omitempty"`
+
+	// Events is the count of events being watched.
+	Events int32 `json:"events,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/obsykagent_controller_test.go
+++ b/internal/controller/obsykagent_controller_test.go
@@ -373,7 +373,7 @@ func TestReconciler_GetResourceCounts(t *testing.T) {
 
 	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
 
-	counts, err := reconciler.getResourceCounts(context.Background())
+	counts, err := reconciler.getResourceCounts(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("getResourceCounts failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Expands ResourceCounts in the ObsykAgent CRD status to track all 20 resource types
- Adds GetResourceCounts() method to ingestion manager for efficient counting
- Updates controller to use ingestion manager for complete resource counts

## Changes

### CRD (api/v1/obsykagent_types.go)
Added 17 new fields to ResourceCounts:
- Nodes, Deployments, StatefulSets, DaemonSets
- Jobs, CronJobs
- Ingresses, NetworkPolicies
- ConfigMaps, Secrets, PVCs, ServiceAccounts
- Roles, ClusterRoles, RoleBindings, ClusterRoleBindings
- Events

### Ingestion Manager (internal/ingestion/manager.go)
- Added `ResourceCounts` struct
- Added `GetResourceCounts()` method that efficiently retrieves counts from informer listers

### Controller (internal/controller/obsykagent_controller.go)
- Updated `getResourceCounts()` to accept agentClient parameter
- Uses ingestion manager's GetResourceCounts() when available
- Falls back to basic API listing (3 types) if manager not ready

## Benefits

- `kubectl get obsykagent` now shows accurate counts for all 20 watched resources
- Status reflects the complete scope of what the agent is monitoring
- Efficient counting from informer caches (no API calls)

## Test Plan

- [x] All tests pass with `-race` flag
- [x] Build succeeds

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)