### PR TITLE
[GH-90] fix: propagate RegisterHandlers errors in all ingesters

### DIFF
--- a/internal/ingestion/clusterrole_ingester.go
+++ b/internal/ingestion/clusterrole_ingester.go
@@ -29,7 +29,8 @@ func NewClusterRoleIngester(factory informers.SharedInformerFactory, cfg Ingeste
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (c *ClusterRoleIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (c *ClusterRoleIngester) RegisterHandlers() error {
 	informer := c.informerFactory.Rbac().V1().ClusterRoles().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (c *ClusterRoleIngester) RegisterHandlers() {
 		UpdateFunc: c.onUpdate,
 		DeleteFunc: c.onDelete,
 	})
-	if err != nil {
-		c.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles ClusterRole addition events.

--- a/internal/ingestion/clusterrole_ingester_test.go
+++ b/internal/ingestion/clusterrole_ingester_test.go
@@ -23,7 +23,7 @@ func TestClusterRoleIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -113,7 +113,7 @@ func TestClusterRoleIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -168,7 +168,7 @@ func TestClusterRoleIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -211,7 +211,7 @@ func TestClusterRoleIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -254,7 +254,7 @@ func TestClusterRoleIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/internal/ingestion/clusterrolebinding_ingester.go
+++ b/internal/ingestion/clusterrolebinding_ingester.go
@@ -29,7 +29,8 @@ func NewClusterRoleBindingIngester(factory informers.SharedInformerFactory, cfg 
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (c *ClusterRoleBindingIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (c *ClusterRoleBindingIngester) RegisterHandlers() error {
 	informer := c.informerFactory.Rbac().V1().ClusterRoleBindings().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (c *ClusterRoleBindingIngester) RegisterHandlers() {
 		UpdateFunc: c.onUpdate,
 		DeleteFunc: c.onDelete,
 	})
-	if err != nil {
-		c.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles ClusterRoleBinding addition events.

--- a/internal/ingestion/clusterrolebinding_ingester_test.go
+++ b/internal/ingestion/clusterrolebinding_ingester_test.go
@@ -23,7 +23,7 @@ func TestClusterRoleBindingIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -125,7 +125,7 @@ func TestClusterRoleBindingIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -183,7 +183,7 @@ func TestClusterRoleBindingIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -226,7 +226,7 @@ func TestClusterRoleBindingIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -277,7 +277,7 @@ func TestClusterRoleBindingIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewClusterRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/internal/ingestion/configmap_ingester.go
+++ b/internal/ingestion/configmap_ingester.go
@@ -35,13 +35,15 @@ func NewConfigMapIngester(factory informers.SharedInformerFactory, cfg IngesterC
 }
 
 // RegisterHandlers registers the event handlers with the informer.
-func (i *ConfigMapIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (i *ConfigMapIngester) RegisterHandlers() error {
 	informer := i.informerFactory.Core().V1().ConfigMaps().Informer()
-	_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    i.onAdd,
 		UpdateFunc: i.onUpdate,
 		DeleteFunc: i.onDelete,
 	})
+	return err
 }
 
 // onAdd handles ConfigMap add events.

--- a/internal/ingestion/configmap_ingester_test.go
+++ b/internal/ingestion/configmap_ingester_test.go
@@ -22,7 +22,7 @@ func TestConfigMapIngester_OnAdd(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewConfigMapIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	immutable := true
 	cm := &corev1.ConfigMap{
@@ -89,7 +89,7 @@ func TestConfigMapIngester_OnUpdate(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewConfigMapIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	oldCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -147,7 +147,7 @@ func TestConfigMapIngester_OnDelete(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewConfigMapIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -187,7 +187,7 @@ func TestConfigMapIngester_ChannelFull(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewConfigMapIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -220,7 +220,7 @@ func TestConfigMapIngester_SkipSameResourceVersion(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewConfigMapIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -254,7 +254,7 @@ func TestConfigMapIngester_SecurityNoDataValues(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewConfigMapIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	sensitiveValue := "THIS-SENSITIVE-VALUE-MUST-NOT-BE-TRANSMITTED"
 	cm := &corev1.ConfigMap{

--- a/internal/ingestion/cronjob_ingester.go
+++ b/internal/ingestion/cronjob_ingester.go
@@ -29,7 +29,8 @@ func NewCronJobIngester(factory informers.SharedInformerFactory, cfg IngesterCon
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (c *CronJobIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (c *CronJobIngester) RegisterHandlers() error {
 	informer := c.informerFactory.Batch().V1().CronJobs().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (c *CronJobIngester) RegisterHandlers() {
 		UpdateFunc: c.onUpdate,
 		DeleteFunc: c.onDelete,
 	})
-	if err != nil {
-		c.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles CronJob addition events.

--- a/internal/ingestion/cronjob_ingester_test.go
+++ b/internal/ingestion/cronjob_ingester_test.go
@@ -23,7 +23,7 @@ func TestCronJobIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -114,7 +114,7 @@ func TestCronJobIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -176,7 +176,7 @@ func TestCronJobIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -226,7 +226,7 @@ func TestCronJobIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -281,7 +281,7 @@ func TestCronJobIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewCronJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/daemonset_ingester.go
+++ b/internal/ingestion/daemonset_ingester.go
@@ -29,7 +29,8 @@ func NewDaemonSetIngester(factory informers.SharedInformerFactory, cfg IngesterC
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (d *DaemonSetIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (d *DaemonSetIngester) RegisterHandlers() error {
 	informer := d.informerFactory.Apps().V1().DaemonSets().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (d *DaemonSetIngester) RegisterHandlers() {
 		UpdateFunc: d.onUpdate,
 		DeleteFunc: d.onDelete,
 	})
-	if err != nil {
-		d.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles DaemonSet addition events.

--- a/internal/ingestion/daemonset_ingester_test.go
+++ b/internal/ingestion/daemonset_ingester_test.go
@@ -24,7 +24,7 @@ func TestDaemonSetIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDaemonSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -150,7 +150,7 @@ func TestDaemonSetIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDaemonSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -223,7 +223,7 @@ func TestDaemonSetIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDaemonSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -273,7 +273,7 @@ func TestDaemonSetIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDaemonSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -352,7 +352,7 @@ func TestDaemonSetIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDaemonSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/deployment_ingester.go
+++ b/internal/ingestion/deployment_ingester.go
@@ -29,7 +29,8 @@ func NewDeploymentIngester(factory informers.SharedInformerFactory, cfg Ingester
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (d *DeploymentIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (d *DeploymentIngester) RegisterHandlers() error {
 	informer := d.informerFactory.Apps().V1().Deployments().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (d *DeploymentIngester) RegisterHandlers() {
 		UpdateFunc: d.onUpdate,
 		DeleteFunc: d.onDelete,
 	})
-	if err != nil {
-		d.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Deployment addition events.

--- a/internal/ingestion/deployment_ingester_test.go
+++ b/internal/ingestion/deployment_ingester_test.go
@@ -24,7 +24,7 @@ func TestDeploymentIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -146,7 +146,7 @@ func TestDeploymentIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -222,7 +222,7 @@ func TestDeploymentIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -272,7 +272,7 @@ func TestDeploymentIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -355,7 +355,7 @@ func TestDeploymentIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewDeploymentIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/event_ingester.go
+++ b/internal/ingestion/event_ingester.go
@@ -29,7 +29,8 @@ func NewEventIngester(factory informers.SharedInformerFactory, cfg IngesterConfi
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (e *EventIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (e *EventIngester) RegisterHandlers() error {
 	informer := e.informerFactory.Core().V1().Events().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (e *EventIngester) RegisterHandlers() {
 		UpdateFunc: e.onUpdate,
 		DeleteFunc: e.onDelete,
 	})
-	if err != nil {
-		e.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Event addition events.

--- a/internal/ingestion/event_ingester_test.go
+++ b/internal/ingestion/event_ingester_test.go
@@ -23,7 +23,7 @@ func TestEventIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewEventIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -128,7 +128,7 @@ func TestEventIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewEventIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -191,7 +191,7 @@ func TestEventIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewEventIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -234,7 +234,7 @@ func TestEventIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewEventIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -283,7 +283,7 @@ func TestEventIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewEventIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -315,7 +315,7 @@ func TestEventIngester_WarningEvent(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewEventIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/internal/ingestion/ingress_ingester.go
+++ b/internal/ingestion/ingress_ingester.go
@@ -29,7 +29,8 @@ func NewIngressIngester(factory informers.SharedInformerFactory, cfg IngesterCon
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (i *IngressIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (i *IngressIngester) RegisterHandlers() error {
 	informer := i.informerFactory.Networking().V1().Ingresses().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (i *IngressIngester) RegisterHandlers() {
 		UpdateFunc: i.onUpdate,
 		DeleteFunc: i.onDelete,
 	})
-	if err != nil {
-		i.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Ingress addition events.

--- a/internal/ingestion/ingress_ingester_test.go
+++ b/internal/ingestion/ingress_ingester_test.go
@@ -23,7 +23,7 @@ func TestIngressIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -159,7 +159,7 @@ func TestIngressIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -217,7 +217,7 @@ func TestIngressIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -267,7 +267,7 @@ func TestIngressIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -316,7 +316,7 @@ func TestIngressIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewIngressIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/job_ingester.go
+++ b/internal/ingestion/job_ingester.go
@@ -29,7 +29,8 @@ func NewJobIngester(factory informers.SharedInformerFactory, cfg IngesterConfig,
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (j *JobIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (j *JobIngester) RegisterHandlers() error {
 	informer := j.informerFactory.Batch().V1().Jobs().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (j *JobIngester) RegisterHandlers() {
 		UpdateFunc: j.onUpdate,
 		DeleteFunc: j.onDelete,
 	})
-	if err != nil {
-		j.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Job addition events.

--- a/internal/ingestion/job_ingester_test.go
+++ b/internal/ingestion/job_ingester_test.go
@@ -23,7 +23,7 @@ func TestJobIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -121,7 +121,7 @@ func TestJobIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -179,7 +179,7 @@ func TestJobIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -229,7 +229,7 @@ func TestJobIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -278,7 +278,7 @@ func TestJobIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewJobIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/manager.go
+++ b/internal/ingestion/manager.go
@@ -156,26 +156,86 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.eventIngester = NewEventIngester(m.informerFactory, ingesterCfg, m.log)
 
 	// Register event handlers before starting factory
-	m.podIngester.RegisterHandlers()
-	m.serviceIngester.RegisterHandlers()
-	m.namespaceIngester.RegisterHandlers()
-	m.nodeIngester.RegisterHandlers()
-	m.deploymentIngester.RegisterHandlers()
-	m.statefulsetIngester.RegisterHandlers()
-	m.daemonsetIngester.RegisterHandlers()
-	m.jobIngester.RegisterHandlers()
-	m.cronjobIngester.RegisterHandlers()
-	m.ingressIngester.RegisterHandlers()
-	m.networkpolicyIngester.RegisterHandlers()
-	m.configmapIngester.RegisterHandlers()
-	m.secretIngester.RegisterHandlers()
-	m.pvcIngester.RegisterHandlers()
-	m.serviceaccountIngester.RegisterHandlers()
-	m.roleIngester.RegisterHandlers()
-	m.clusterroleIngester.RegisterHandlers()
-	m.rolebindingIngester.RegisterHandlers()
-	m.clusterrolebindingIngester.RegisterHandlers()
-	m.eventIngester.RegisterHandlers()
+	if err := m.podIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering pod handler: %w", err)
+	}
+	if err := m.serviceIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering service handler: %w", err)
+	}
+	if err := m.namespaceIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering namespace handler: %w", err)
+	}
+	if err := m.nodeIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering node handler: %w", err)
+	}
+	if err := m.deploymentIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering deployment handler: %w", err)
+	}
+	if err := m.statefulsetIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering statefulset handler: %w", err)
+	}
+	if err := m.daemonsetIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering daemonset handler: %w", err)
+	}
+	if err := m.jobIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering job handler: %w", err)
+	}
+	if err := m.cronjobIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering cronjob handler: %w", err)
+	}
+	if err := m.ingressIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering ingress handler: %w", err)
+	}
+	if err := m.networkpolicyIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering networkpolicy handler: %w", err)
+	}
+	if err := m.configmapIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering configmap handler: %w", err)
+	}
+	if err := m.secretIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering secret handler: %w", err)
+	}
+	if err := m.pvcIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering pvc handler: %w", err)
+	}
+	if err := m.serviceaccountIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering serviceaccount handler: %w", err)
+	}
+	if err := m.roleIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering role handler: %w", err)
+	}
+	if err := m.clusterroleIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering clusterrole handler: %w", err)
+	}
+	if err := m.rolebindingIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering rolebinding handler: %w", err)
+	}
+	if err := m.clusterrolebindingIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering clusterrolebinding handler: %w", err)
+	}
+	if err := m.eventIngester.RegisterHandlers(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("registering event handler: %w", err)
+	}
 
 	// Start event processor goroutine
 	go m.processEvents(procCtx)

--- a/internal/ingestion/namespace_ingester.go
+++ b/internal/ingestion/namespace_ingester.go
@@ -29,7 +29,8 @@ func NewNamespaceIngester(factory informers.SharedInformerFactory, cfg IngesterC
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (n *NamespaceIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (n *NamespaceIngester) RegisterHandlers() error {
 	informer := n.informerFactory.Core().V1().Namespaces().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (n *NamespaceIngester) RegisterHandlers() {
 		UpdateFunc: n.onUpdate,
 		DeleteFunc: n.onDelete,
 	})
-	if err != nil {
-		n.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Namespace addition events.

--- a/internal/ingestion/namespace_ingester_test.go
+++ b/internal/ingestion/namespace_ingester_test.go
@@ -23,7 +23,7 @@ func TestNamespaceIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNamespaceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -84,7 +84,7 @@ func TestNamespaceIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNamespaceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -138,7 +138,7 @@ func TestNamespaceIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNamespaceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -184,7 +184,7 @@ func TestNamespaceIngester_ClusterScoped(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNamespaceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/networkpolicy_ingester.go
+++ b/internal/ingestion/networkpolicy_ingester.go
@@ -29,7 +29,8 @@ func NewNetworkPolicyIngester(factory informers.SharedInformerFactory, cfg Inges
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (n *NetworkPolicyIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (n *NetworkPolicyIngester) RegisterHandlers() error {
 	informer := n.informerFactory.Networking().V1().NetworkPolicies().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (n *NetworkPolicyIngester) RegisterHandlers() {
 		UpdateFunc: n.onUpdate,
 		DeleteFunc: n.onDelete,
 	})
-	if err != nil {
-		n.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles NetworkPolicy addition events.

--- a/internal/ingestion/networkpolicy_ingester_test.go
+++ b/internal/ingestion/networkpolicy_ingester_test.go
@@ -23,7 +23,7 @@ func TestNetworkPolicyIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -164,7 +164,7 @@ func TestNetworkPolicyIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -222,7 +222,7 @@ func TestNetworkPolicyIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -272,7 +272,7 @@ func TestNetworkPolicyIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -321,7 +321,7 @@ func TestNetworkPolicyIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNetworkPolicyIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/node_ingester.go
+++ b/internal/ingestion/node_ingester.go
@@ -29,7 +29,8 @@ func NewNodeIngester(factory informers.SharedInformerFactory, cfg IngesterConfig
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (n *NodeIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (n *NodeIngester) RegisterHandlers() error {
 	informer := n.informerFactory.Core().V1().Nodes().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (n *NodeIngester) RegisterHandlers() {
 		UpdateFunc: n.onUpdate,
 		DeleteFunc: n.onDelete,
 	})
-	if err != nil {
-		n.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Node addition events.

--- a/internal/ingestion/node_ingester_test.go
+++ b/internal/ingestion/node_ingester_test.go
@@ -24,7 +24,7 @@ func TestNodeIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNodeIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -129,7 +129,7 @@ func TestNodeIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNodeIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -186,7 +186,7 @@ func TestNodeIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNodeIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -236,7 +236,7 @@ func TestNodeIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNodeIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -283,7 +283,7 @@ func TestNodeIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewNodeIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/pod_ingester.go
+++ b/internal/ingestion/pod_ingester.go
@@ -29,7 +29,8 @@ func NewPodIngester(factory informers.SharedInformerFactory, cfg IngesterConfig,
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (p *PodIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (p *PodIngester) RegisterHandlers() error {
 	informer := p.informerFactory.Core().V1().Pods().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (p *PodIngester) RegisterHandlers() {
 		UpdateFunc: p.onUpdate,
 		DeleteFunc: p.onDelete,
 	})
-	if err != nil {
-		p.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Pod addition events.

--- a/internal/ingestion/pod_ingester_test.go
+++ b/internal/ingestion/pod_ingester_test.go
@@ -23,7 +23,7 @@ func TestPodIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPodIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -93,7 +93,7 @@ func TestPodIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPodIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -151,7 +151,7 @@ func TestPodIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPodIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -201,7 +201,7 @@ func TestPodIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPodIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -250,7 +250,7 @@ func TestPodIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPodIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/pvc_ingester.go
+++ b/internal/ingestion/pvc_ingester.go
@@ -29,7 +29,8 @@ func NewPVCIngester(factory informers.SharedInformerFactory, cfg IngesterConfig,
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (i *PVCIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (i *PVCIngester) RegisterHandlers() error {
 	informer := i.informerFactory.Core().V1().PersistentVolumeClaims().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (i *PVCIngester) RegisterHandlers() {
 		UpdateFunc: i.onUpdate,
 		DeleteFunc: i.onDelete,
 	})
-	if err != nil {
-		i.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles PVC addition events.

--- a/internal/ingestion/pvc_ingester_test.go
+++ b/internal/ingestion/pvc_ingester_test.go
@@ -25,7 +25,7 @@ func TestPVCIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -131,7 +131,7 @@ func TestPVCIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -202,7 +202,7 @@ func TestPVCIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -252,7 +252,7 @@ func TestPVCIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -301,7 +301,7 @@ func TestPVCIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -359,7 +359,7 @@ func TestPVCIngester_PVCPhases(t *testing.T) {
 			log := ctrl.Log.WithName("test")
 
 			ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-			ingester.RegisterHandlers()
+			_ = ingester.RegisterHandlers()
 
 			// Start informer
 			stopCh := make(chan struct{})
@@ -406,7 +406,7 @@ func TestPVCIngester_AccessModes(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewPVCIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/role_ingester.go
+++ b/internal/ingestion/role_ingester.go
@@ -29,7 +29,8 @@ func NewRoleIngester(factory informers.SharedInformerFactory, cfg IngesterConfig
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (r *RoleIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (r *RoleIngester) RegisterHandlers() error {
 	informer := r.informerFactory.Rbac().V1().Roles().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (r *RoleIngester) RegisterHandlers() {
 		UpdateFunc: r.onUpdate,
 		DeleteFunc: r.onDelete,
 	})
-	if err != nil {
-		r.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Role addition events.

--- a/internal/ingestion/role_ingester_test.go
+++ b/internal/ingestion/role_ingester_test.go
@@ -23,7 +23,7 @@ func TestRoleIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -115,7 +115,7 @@ func TestRoleIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -171,7 +171,7 @@ func TestRoleIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -214,7 +214,7 @@ func TestRoleIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -259,7 +259,7 @@ func TestRoleIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/internal/ingestion/rolebinding_ingester.go
+++ b/internal/ingestion/rolebinding_ingester.go
@@ -29,7 +29,8 @@ func NewRoleBindingIngester(factory informers.SharedInformerFactory, cfg Ingeste
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (r *RoleBindingIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (r *RoleBindingIngester) RegisterHandlers() error {
 	informer := r.informerFactory.Rbac().V1().RoleBindings().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (r *RoleBindingIngester) RegisterHandlers() {
 		UpdateFunc: r.onUpdate,
 		DeleteFunc: r.onDelete,
 	})
-	if err != nil {
-		r.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles RoleBinding addition events.

--- a/internal/ingestion/rolebinding_ingester_test.go
+++ b/internal/ingestion/rolebinding_ingester_test.go
@@ -23,7 +23,7 @@ func TestRoleBindingIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -127,7 +127,7 @@ func TestRoleBindingIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -186,7 +186,7 @@ func TestRoleBindingIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -229,7 +229,7 @@ func TestRoleBindingIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -282,7 +282,7 @@ func TestRoleBindingIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewRoleBindingIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/internal/ingestion/secret_ingester.go
+++ b/internal/ingestion/secret_ingester.go
@@ -37,13 +37,15 @@ func NewSecretIngester(factory informers.SharedInformerFactory, cfg IngesterConf
 }
 
 // RegisterHandlers registers the event handlers with the informer.
-func (i *SecretIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (i *SecretIngester) RegisterHandlers() error {
 	informer := i.informerFactory.Core().V1().Secrets().Informer()
-	_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    i.onAdd,
 		UpdateFunc: i.onUpdate,
 		DeleteFunc: i.onDelete,
 	})
+	return err
 }
 
 // onAdd handles Secret add events.

--- a/internal/ingestion/secret_ingester_test.go
+++ b/internal/ingestion/secret_ingester_test.go
@@ -23,7 +23,7 @@ func TestSecretIngester_OnAdd(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	immutable := true
 	secret := &corev1.Secret{
@@ -88,7 +88,7 @@ func TestSecretIngester_OnUpdate(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	oldSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -148,7 +148,7 @@ func TestSecretIngester_OnDelete(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -188,7 +188,7 @@ func TestSecretIngester_ChannelFull(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -221,7 +221,7 @@ func TestSecretIngester_SkipSameResourceVersion(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -256,7 +256,7 @@ func TestSecretIngester_SecurityNoDataValues(t *testing.T) {
 	log := testr.New(t)
 
 	ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Create a secret with highly sensitive data
 	sensitivePassword := "SUPER-SECRET-DATABASE-PASSWORD-12345"
@@ -366,7 +366,7 @@ func TestSecretIngester_SecretTypes(t *testing.T) {
 			log := testr.New(t)
 
 			ingester := NewSecretIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-			ingester.RegisterHandlers()
+			_ = ingester.RegisterHandlers()
 
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/ingestion/service_ingester.go
+++ b/internal/ingestion/service_ingester.go
@@ -29,7 +29,8 @@ func NewServiceIngester(factory informers.SharedInformerFactory, cfg IngesterCon
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (s *ServiceIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (s *ServiceIngester) RegisterHandlers() error {
 	informer := s.informerFactory.Core().V1().Services().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (s *ServiceIngester) RegisterHandlers() {
 		UpdateFunc: s.onUpdate,
 		DeleteFunc: s.onDelete,
 	})
-	if err != nil {
-		s.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles Service addition events.

--- a/internal/ingestion/service_ingester_test.go
+++ b/internal/ingestion/service_ingester_test.go
@@ -23,7 +23,7 @@ func TestServiceIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -94,7 +94,7 @@ func TestServiceIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -149,7 +149,7 @@ func TestServiceIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})

--- a/internal/ingestion/serviceaccount_ingester.go
+++ b/internal/ingestion/serviceaccount_ingester.go
@@ -29,7 +29,8 @@ func NewServiceAccountIngester(factory informers.SharedInformerFactory, cfg Inge
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (s *ServiceAccountIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (s *ServiceAccountIngester) RegisterHandlers() error {
 	informer := s.informerFactory.Core().V1().ServiceAccounts().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (s *ServiceAccountIngester) RegisterHandlers() {
 		UpdateFunc: s.onUpdate,
 		DeleteFunc: s.onDelete,
 	})
-	if err != nil {
-		s.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles ServiceAccount addition events.

--- a/internal/ingestion/serviceaccount_ingester_test.go
+++ b/internal/ingestion/serviceaccount_ingester_test.go
@@ -23,7 +23,7 @@ func TestServiceAccountIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -105,7 +105,7 @@ func TestServiceAccountIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -157,7 +157,7 @@ func TestServiceAccountIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -200,7 +200,7 @@ func TestServiceAccountIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -245,7 +245,7 @@ func TestServiceAccountIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewServiceAccountIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/internal/ingestion/statefulset_ingester.go
+++ b/internal/ingestion/statefulset_ingester.go
@@ -29,7 +29,8 @@ func NewStatefulSetIngester(factory informers.SharedInformerFactory, cfg Ingeste
 
 // RegisterHandlers registers the event handlers with the informer.
 // This must be called before starting the informer factory.
-func (s *StatefulSetIngester) RegisterHandlers() {
+// Returns an error if handler registration fails.
+func (s *StatefulSetIngester) RegisterHandlers() error {
 	informer := s.informerFactory.Apps().V1().StatefulSets().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -37,9 +38,7 @@ func (s *StatefulSetIngester) RegisterHandlers() {
 		UpdateFunc: s.onUpdate,
 		DeleteFunc: s.onDelete,
 	})
-	if err != nil {
-		s.log.Error(err, "failed to add event handler")
-	}
+	return err
 }
 
 // onAdd handles StatefulSet addition events.

--- a/internal/ingestion/statefulset_ingester_test.go
+++ b/internal/ingestion/statefulset_ingester_test.go
@@ -24,7 +24,7 @@ func TestStatefulSetIngester_OnAdd(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -150,7 +150,7 @@ func TestStatefulSetIngester_OnUpdate(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -227,7 +227,7 @@ func TestStatefulSetIngester_OnDelete(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -277,7 +277,7 @@ func TestStatefulSetIngester_ChannelFull(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})
@@ -362,7 +362,7 @@ func TestStatefulSetIngester_SkipSameResourceVersion(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 
 	ingester := NewStatefulSetIngester(factory, IngesterConfig{EventChan: eventChan}, log)
-	ingester.RegisterHandlers()
+	_ = ingester.RegisterHandlers()
 
 	// Start informer
 	stopCh := make(chan struct{})


### PR DESCRIPTION
## Summary
- Changed all 20 ingesters to return errors from `RegisterHandlers()` instead of silently discarding them
- Manager.Start() now checks these errors and fails fast if any handler registration fails
- Updated all test files to handle error return values

## Problem
- Secret/ConfigMap ingesters explicitly discarded errors with `_, _`
- Other ingesters logged errors but continued silently
- This caused silent failures when handler registration failed

## Test plan
- [x] All ingestion tests pass
- [x] Full CI (`make ci`) passes
- [x] Linter passes (errcheck)

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)