### PR TITLE
[GH-92] fix: standardize logging for channel full events

### DIFF
--- a/internal/ingestion/clusterrole_ingester.go
+++ b/internal/ingestion/clusterrole_ingester.go
@@ -114,7 +114,7 @@ func (c *ClusterRoleIngester) sendEvent(eventType transport.EventType, clusterRo
 	select {
 	case c.config.EventChan <- event:
 	default:
-		c.log.Error(nil, "event channel full, dropping event",
+		c.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", clusterRole.Name)
 	}
@@ -134,7 +134,7 @@ func (c *ClusterRoleIngester) sendDeleteEvent(clusterRole *rbacv1.ClusterRole) {
 	select {
 	case c.config.EventChan <- event:
 	default:
-		c.log.Error(nil, "event channel full, dropping delete event",
+		c.log.Info("event channel full, dropping delete event",
 			"name", clusterRole.Name)
 	}
 }

--- a/internal/ingestion/clusterrolebinding_ingester.go
+++ b/internal/ingestion/clusterrolebinding_ingester.go
@@ -114,7 +114,7 @@ func (c *ClusterRoleBindingIngester) sendEvent(eventType transport.EventType, cr
 	select {
 	case c.config.EventChan <- event:
 	default:
-		c.log.Error(nil, "event channel full, dropping event",
+		c.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", crb.Name)
 	}
@@ -134,7 +134,7 @@ func (c *ClusterRoleBindingIngester) sendDeleteEvent(crb *rbacv1.ClusterRoleBind
 	select {
 	case c.config.EventChan <- event:
 	default:
-		c.log.Error(nil, "event channel full, dropping delete event",
+		c.log.Info("event channel full, dropping delete event",
 			"name", crb.Name)
 	}
 }

--- a/internal/ingestion/configmap_ingester.go
+++ b/internal/ingestion/configmap_ingester.go
@@ -132,7 +132,7 @@ func (i *ConfigMapIngester) sendEvent(eventType transport.EventType, cm *corev1.
 	case i.config.EventChan <- event:
 		// Event sent successfully
 	default:
-		i.log.Info("event channel full, dropping ConfigMap event",
+		i.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", cm.Name,
 			"namespace", cm.Namespace)
@@ -154,7 +154,7 @@ func (i *ConfigMapIngester) sendDeleteEvent(cm *corev1.ConfigMap) {
 	case i.config.EventChan <- event:
 		// Event sent successfully
 	default:
-		i.log.Info("event channel full, dropping ConfigMap delete event",
+		i.log.Info("event channel full, dropping delete event",
 			"name", cm.Name,
 			"namespace", cm.Namespace)
 	}

--- a/internal/ingestion/cronjob_ingester.go
+++ b/internal/ingestion/cronjob_ingester.go
@@ -117,7 +117,7 @@ func (c *CronJobIngester) sendEvent(eventType transport.EventType, cj *batchv1.C
 	select {
 	case c.config.EventChan <- event:
 	default:
-		c.log.Error(nil, "event channel full, dropping event",
+		c.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", cj.Name,
 			"namespace", cj.Namespace)
@@ -138,7 +138,7 @@ func (c *CronJobIngester) sendDeleteEvent(cj *batchv1.CronJob) {
 	select {
 	case c.config.EventChan <- event:
 	default:
-		c.log.Error(nil, "event channel full, dropping delete event",
+		c.log.Info("event channel full, dropping delete event",
 			"name", cj.Name,
 			"namespace", cj.Namespace)
 	}

--- a/internal/ingestion/daemonset_ingester.go
+++ b/internal/ingestion/daemonset_ingester.go
@@ -117,7 +117,7 @@ func (d *DaemonSetIngester) sendEvent(eventType transport.EventType, ds *appsv1.
 	select {
 	case d.config.EventChan <- event:
 	default:
-		d.log.Error(nil, "event channel full, dropping event",
+		d.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", ds.Name,
 			"namespace", ds.Namespace)
@@ -138,7 +138,7 @@ func (d *DaemonSetIngester) sendDeleteEvent(ds *appsv1.DaemonSet) {
 	select {
 	case d.config.EventChan <- event:
 	default:
-		d.log.Error(nil, "event channel full, dropping delete event",
+		d.log.Info("event channel full, dropping delete event",
 			"name", ds.Name,
 			"namespace", ds.Namespace)
 	}

--- a/internal/ingestion/deployment_ingester.go
+++ b/internal/ingestion/deployment_ingester.go
@@ -117,7 +117,7 @@ func (d *DeploymentIngester) sendEvent(eventType transport.EventType, deploy *ap
 	select {
 	case d.config.EventChan <- event:
 	default:
-		d.log.Error(nil, "event channel full, dropping event",
+		d.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", deploy.Name,
 			"namespace", deploy.Namespace)
@@ -138,7 +138,7 @@ func (d *DeploymentIngester) sendDeleteEvent(deploy *appsv1.Deployment) {
 	select {
 	case d.config.EventChan <- event:
 	default:
-		d.log.Error(nil, "event channel full, dropping delete event",
+		d.log.Info("event channel full, dropping delete event",
 			"name", deploy.Name,
 			"namespace", deploy.Namespace)
 	}

--- a/internal/ingestion/event_ingester.go
+++ b/internal/ingestion/event_ingester.go
@@ -119,7 +119,7 @@ func (e *EventIngester) sendEvent(eventType transport.EventType, event *corev1.E
 	select {
 	case e.config.EventChan <- resourceEvent:
 	default:
-		e.log.Error(nil, "event channel full, dropping event",
+		e.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", event.Name,
 			"namespace", event.Namespace)
@@ -140,7 +140,7 @@ func (e *EventIngester) sendDeleteEvent(event *corev1.Event) {
 	select {
 	case e.config.EventChan <- resourceEvent:
 	default:
-		e.log.Error(nil, "event channel full, dropping delete event",
+		e.log.Info("event channel full, dropping delete event",
 			"name", event.Name,
 			"namespace", event.Namespace)
 	}

--- a/internal/ingestion/ingress_ingester.go
+++ b/internal/ingestion/ingress_ingester.go
@@ -117,7 +117,7 @@ func (i *IngressIngester) sendEvent(eventType transport.EventType, ing *networki
 	select {
 	case i.config.EventChan <- event:
 	default:
-		i.log.Error(nil, "event channel full, dropping event",
+		i.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", ing.Name,
 			"namespace", ing.Namespace)
@@ -138,7 +138,7 @@ func (i *IngressIngester) sendDeleteEvent(ing *networkingv1.Ingress) {
 	select {
 	case i.config.EventChan <- event:
 	default:
-		i.log.Error(nil, "event channel full, dropping delete event",
+		i.log.Info("event channel full, dropping delete event",
 			"name", ing.Name,
 			"namespace", ing.Namespace)
 	}

--- a/internal/ingestion/job_ingester.go
+++ b/internal/ingestion/job_ingester.go
@@ -117,7 +117,7 @@ func (j *JobIngester) sendEvent(eventType transport.EventType, job *batchv1.Job)
 	select {
 	case j.config.EventChan <- event:
 	default:
-		j.log.Error(nil, "event channel full, dropping event",
+		j.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", job.Name,
 			"namespace", job.Namespace)
@@ -138,7 +138,7 @@ func (j *JobIngester) sendDeleteEvent(job *batchv1.Job) {
 	select {
 	case j.config.EventChan <- event:
 	default:
-		j.log.Error(nil, "event channel full, dropping delete event",
+		j.log.Info("event channel full, dropping delete event",
 			"name", job.Name,
 			"namespace", job.Namespace)
 	}

--- a/internal/ingestion/namespace_ingester.go
+++ b/internal/ingestion/namespace_ingester.go
@@ -113,7 +113,7 @@ func (n *NamespaceIngester) sendEvent(eventType transport.EventType, ns *corev1.
 	select {
 	case n.config.EventChan <- event:
 	default:
-		n.log.Error(nil, "event channel full, dropping event",
+		n.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", ns.Name)
 	}
@@ -133,7 +133,7 @@ func (n *NamespaceIngester) sendDeleteEvent(ns *corev1.Namespace) {
 	select {
 	case n.config.EventChan <- event:
 	default:
-		n.log.Error(nil, "event channel full, dropping delete event",
+		n.log.Info("event channel full, dropping delete event",
 			"name", ns.Name)
 	}
 }

--- a/internal/ingestion/networkpolicy_ingester.go
+++ b/internal/ingestion/networkpolicy_ingester.go
@@ -117,7 +117,7 @@ func (n *NetworkPolicyIngester) sendEvent(eventType transport.EventType, np *net
 	select {
 	case n.config.EventChan <- event:
 	default:
-		n.log.Error(nil, "event channel full, dropping event",
+		n.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", np.Name,
 			"namespace", np.Namespace)
@@ -138,7 +138,7 @@ func (n *NetworkPolicyIngester) sendDeleteEvent(np *networkingv1.NetworkPolicy) 
 	select {
 	case n.config.EventChan <- event:
 	default:
-		n.log.Error(nil, "event channel full, dropping delete event",
+		n.log.Info("event channel full, dropping delete event",
 			"name", np.Name,
 			"namespace", np.Namespace)
 	}

--- a/internal/ingestion/node_ingester.go
+++ b/internal/ingestion/node_ingester.go
@@ -114,7 +114,7 @@ func (n *NodeIngester) sendEvent(eventType transport.EventType, node *corev1.Nod
 	select {
 	case n.config.EventChan <- event:
 	default:
-		n.log.Error(nil, "event channel full, dropping event",
+		n.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", node.Name)
 	}
@@ -134,7 +134,7 @@ func (n *NodeIngester) sendDeleteEvent(node *corev1.Node) {
 	select {
 	case n.config.EventChan <- event:
 	default:
-		n.log.Error(nil, "event channel full, dropping delete event",
+		n.log.Info("event channel full, dropping delete event",
 			"name", node.Name)
 	}
 }

--- a/internal/ingestion/pod_ingester.go
+++ b/internal/ingestion/pod_ingester.go
@@ -117,7 +117,7 @@ func (p *PodIngester) sendEvent(eventType transport.EventType, pod *corev1.Pod) 
 	select {
 	case p.config.EventChan <- event:
 	default:
-		p.log.Error(nil, "event channel full, dropping event",
+		p.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", pod.Name,
 			"namespace", pod.Namespace)
@@ -138,7 +138,7 @@ func (p *PodIngester) sendDeleteEvent(pod *corev1.Pod) {
 	select {
 	case p.config.EventChan <- event:
 	default:
-		p.log.Error(nil, "event channel full, dropping delete event",
+		p.log.Info("event channel full, dropping delete event",
 			"name", pod.Name,
 			"namespace", pod.Namespace)
 	}

--- a/internal/ingestion/pvc_ingester.go
+++ b/internal/ingestion/pvc_ingester.go
@@ -118,7 +118,7 @@ func (i *PVCIngester) sendEvent(eventType transport.EventType, pvc *corev1.Persi
 	select {
 	case i.config.EventChan <- event:
 	default:
-		i.log.Info("event channel full, dropping PVC event",
+		i.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", pvc.Name,
 			"namespace", pvc.Namespace)
@@ -139,7 +139,7 @@ func (i *PVCIngester) sendDeleteEvent(pvc *corev1.PersistentVolumeClaim) {
 	select {
 	case i.config.EventChan <- event:
 	default:
-		i.log.Info("event channel full, dropping PVC delete event",
+		i.log.Info("event channel full, dropping delete event",
 			"name", pvc.Name,
 			"namespace", pvc.Namespace)
 	}

--- a/internal/ingestion/role_ingester.go
+++ b/internal/ingestion/role_ingester.go
@@ -117,7 +117,7 @@ func (r *RoleIngester) sendEvent(eventType transport.EventType, role *rbacv1.Rol
 	select {
 	case r.config.EventChan <- event:
 	default:
-		r.log.Error(nil, "event channel full, dropping event",
+		r.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", role.Name,
 			"namespace", role.Namespace)
@@ -138,7 +138,7 @@ func (r *RoleIngester) sendDeleteEvent(role *rbacv1.Role) {
 	select {
 	case r.config.EventChan <- event:
 	default:
-		r.log.Error(nil, "event channel full, dropping delete event",
+		r.log.Info("event channel full, dropping delete event",
 			"name", role.Name,
 			"namespace", role.Namespace)
 	}

--- a/internal/ingestion/rolebinding_ingester.go
+++ b/internal/ingestion/rolebinding_ingester.go
@@ -117,7 +117,7 @@ func (r *RoleBindingIngester) sendEvent(eventType transport.EventType, rb *rbacv
 	select {
 	case r.config.EventChan <- event:
 	default:
-		r.log.Error(nil, "event channel full, dropping event",
+		r.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", rb.Name,
 			"namespace", rb.Namespace)
@@ -138,7 +138,7 @@ func (r *RoleBindingIngester) sendDeleteEvent(rb *rbacv1.RoleBinding) {
 	select {
 	case r.config.EventChan <- event:
 	default:
-		r.log.Error(nil, "event channel full, dropping delete event",
+		r.log.Info("event channel full, dropping delete event",
 			"name", rb.Name,
 			"namespace", rb.Namespace)
 	}

--- a/internal/ingestion/secret_ingester.go
+++ b/internal/ingestion/secret_ingester.go
@@ -139,7 +139,7 @@ func (i *SecretIngester) sendEvent(eventType transport.EventType, secret *corev1
 	case i.config.EventChan <- event:
 		// Event sent successfully
 	default:
-		i.log.Info("event channel full, dropping Secret event",
+		i.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", secret.Name,
 			"namespace", secret.Namespace)
@@ -161,7 +161,7 @@ func (i *SecretIngester) sendDeleteEvent(secret *corev1.Secret) {
 	case i.config.EventChan <- event:
 		// Event sent successfully
 	default:
-		i.log.Info("event channel full, dropping Secret delete event",
+		i.log.Info("event channel full, dropping delete event",
 			"name", secret.Name,
 			"namespace", secret.Namespace)
 	}

--- a/internal/ingestion/service_ingester.go
+++ b/internal/ingestion/service_ingester.go
@@ -116,7 +116,7 @@ func (s *ServiceIngester) sendEvent(eventType transport.EventType, svc *corev1.S
 	select {
 	case s.config.EventChan <- event:
 	default:
-		s.log.Error(nil, "event channel full, dropping event",
+		s.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", svc.Name,
 			"namespace", svc.Namespace)
@@ -137,7 +137,7 @@ func (s *ServiceIngester) sendDeleteEvent(svc *corev1.Service) {
 	select {
 	case s.config.EventChan <- event:
 	default:
-		s.log.Error(nil, "event channel full, dropping delete event",
+		s.log.Info("event channel full, dropping delete event",
 			"name", svc.Name,
 			"namespace", svc.Namespace)
 	}

--- a/internal/ingestion/serviceaccount_ingester.go
+++ b/internal/ingestion/serviceaccount_ingester.go
@@ -117,7 +117,7 @@ func (s *ServiceAccountIngester) sendEvent(eventType transport.EventType, sa *co
 	select {
 	case s.config.EventChan <- event:
 	default:
-		s.log.Error(nil, "event channel full, dropping event",
+		s.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", sa.Name,
 			"namespace", sa.Namespace)
@@ -138,7 +138,7 @@ func (s *ServiceAccountIngester) sendDeleteEvent(sa *corev1.ServiceAccount) {
 	select {
 	case s.config.EventChan <- event:
 	default:
-		s.log.Error(nil, "event channel full, dropping delete event",
+		s.log.Info("event channel full, dropping delete event",
 			"name", sa.Name,
 			"namespace", sa.Namespace)
 	}

--- a/internal/ingestion/statefulset_ingester.go
+++ b/internal/ingestion/statefulset_ingester.go
@@ -117,7 +117,7 @@ func (s *StatefulSetIngester) sendEvent(eventType transport.EventType, sts *apps
 	select {
 	case s.config.EventChan <- event:
 	default:
-		s.log.Error(nil, "event channel full, dropping event",
+		s.log.Info("event channel full, dropping event",
 			"type", eventType,
 			"name", sts.Name,
 			"namespace", sts.Namespace)
@@ -138,7 +138,7 @@ func (s *StatefulSetIngester) sendDeleteEvent(sts *appsv1.StatefulSet) {
 	select {
 	case s.config.EventChan <- event:
 	default:
-		s.log.Error(nil, "event channel full, dropping delete event",
+		s.log.Info("event channel full, dropping delete event",
 			"name", sts.Name,
 			"namespace", sts.Namespace)
 	}


### PR DESCRIPTION
## Summary
- Standardizes logging level for "event channel full" across all 20 ingesters
- Changes `Error(nil, ...)` to `Info()` since channel full is expected under high load
- Unifies message format to `"event channel full, dropping event"` for all resource types

**Before:**
- 17 ingesters used `Error(nil, "event channel full, dropping event", ...)`
- ConfigMap used `Info("event channel full, dropping ConfigMap event", ...)`
- Secret used `Info("event channel full, dropping Secret event", ...)`
- PVC used `Info("event channel full, dropping PVC event", ...)`

**After:**
- All 20 ingesters use `Info("event channel full, dropping event", ...)` or `Info("event channel full, dropping delete event", ...)`

## Test plan
- [x] All ingestion tests pass
- [x] Log output in tests shows consistent `INFO` level messages
- [x] `make ci` passes

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)