### PR TITLE
[GH-94] feat: inject version at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:26111811bc967321e7b6f85
 ARG TARGETOS
 ARG TARGETARCH
 
+# Version is passed at build time, defaults to "dev"
+ARG VERSION=dev
+
 WORKDIR /workspace
 
 # Install build dependencies
@@ -24,8 +27,8 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 COPY api/ api/
 
-# Build for target platform
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/main.go
+# Build for target platform with version injected
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X main.version=${VERSION}" -a -o manager ./cmd/main.go
 
 # Runtime stage
 # Pinned to manifest list digest for supply chain security (supports all platforms)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,10 @@ import (
 )
 
 var (
+	// version is set at build time via ldflags.
+	// Example: go build -ldflags="-X main.version=v1.0.0"
+	version = "dev"
+
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
@@ -73,6 +77,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("starting operator", "version", version)
+
 	// Register ObsykAgent controller
 	// Pass APIReader for direct API calls (secrets) without cluster-wide caching
 	// Pass clientset for SharedInformerFactory used by ingestion manager
@@ -81,6 +87,7 @@ func main() {
 		mgr.GetAPIReader(),
 		mgr.GetScheme(),
 		clientset,
+		version,
 	)
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ObsykAgent")

--- a/internal/controller/obsykagent_controller_test.go
+++ b/internal/controller/obsykagent_controller_test.go
@@ -53,7 +53,7 @@ func TestNewObsykAgentReconciler(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	if reconciler == nil {
 		t.Fatal("expected non-nil reconciler")
@@ -63,6 +63,9 @@ func TestNewObsykAgentReconciler(t *testing.T) {
 	}
 	if reconciler.httpClient == nil {
 		t.Error("expected httpClient to be initialized")
+	}
+	if reconciler.version != "test-version" {
+		t.Errorf("expected version 'test-version', got '%s'", reconciler.version)
 	}
 }
 
@@ -111,7 +114,7 @@ func TestReconciler_ConcurrentAgentClientAccess(t *testing.T) {
 	}
 	fakeClient := clientBuilder.Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// Concurrently call getOrCreateAgentClient for different agents
 	var wg sync.WaitGroup
@@ -184,7 +187,7 @@ func TestReconciler_ConcurrentDeleteAndCreate(t *testing.T) {
 		WithObjects(secret, agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -239,7 +242,7 @@ func TestReconciler_ReconcileNotFound(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// Pre-populate with a client that should be deleted
 	reconciler.agentClientsMu.Lock()
@@ -279,7 +282,7 @@ func TestReconciler_CheckPlatformHealth(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// With no agents, should be healthy
 	err := reconciler.CheckPlatformHealth()
@@ -295,7 +298,7 @@ func TestReconciler_CheckReady(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// With no agents, should be ready
 	err := reconciler.CheckReady()
@@ -322,7 +325,7 @@ func TestReconciler_GetClusterUID(t *testing.T) {
 		WithObjects(kubeSystemNS).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	uid, err := reconciler.getClusterUID(context.Background())
 	if err != nil {
@@ -341,7 +344,7 @@ func TestReconciler_GetClusterUIDNotFound(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	_, err := reconciler.getClusterUID(context.Background())
 	if err == nil {
@@ -371,7 +374,7 @@ func TestReconciler_GetResourceCounts(t *testing.T) {
 		WithObjects(ns, pod, svc).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	counts, err := reconciler.getResourceCounts(context.Background(), nil)
 	if err != nil {
@@ -396,7 +399,7 @@ func TestReconciler_SetCondition(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	agent := &obsykv1.ObsykAgent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -466,7 +469,7 @@ func TestReconciler_GetCredentials(t *testing.T) {
 		WithObjects(secret).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	creds, err := reconciler.getCredentials(context.Background(), agent)
 	if err != nil {
@@ -497,7 +500,7 @@ func TestReconciler_GetCredentialsNotFound(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	_, err := reconciler.getCredentials(context.Background(), agent)
 	if err == nil {
@@ -529,7 +532,7 @@ func TestReconciler_FindAgentsForResource(t *testing.T) {
 		WithObjects(agent1, agent2).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// Create a test pod to trigger the lookup
 	pod := &corev1.Pod{
@@ -584,7 +587,7 @@ func TestReconciler_CheckPlatformHealthWithUnhealthyAgent(t *testing.T) {
 		WithObjects(secret, agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// Create an agent client (which will be unhealthy initially since it has never connected)
 	_, err := reconciler.getOrCreateAgentClient(context.Background(), agent)
@@ -637,7 +640,7 @@ func TestReconciler_CheckReadyWithNoSyncedAgent(t *testing.T) {
 		WithObjects(secret, agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	// Create an agent client (which will not have synced initially)
 	_, err := reconciler.getOrCreateAgentClient(context.Background(), agent)
@@ -699,7 +702,7 @@ func TestReconciler_ReconcileAgentExists(t *testing.T) {
 		WithStatusSubresource(agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -742,7 +745,7 @@ func TestReconciler_ReconcileMissingSecret(t *testing.T) {
 		WithStatusSubresource(agent).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -793,7 +796,7 @@ func TestReconciler_GetCredentialsInvalidKey(t *testing.T) {
 		WithObjects(secret).
 		Build()
 
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	_, err := reconciler.getCredentials(context.Background(), agent)
 	if err == nil {
@@ -808,7 +811,7 @@ func TestReconciler_FindAgentsForResourceEmpty(t *testing.T) {
 	_ = obsykv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil)
+	reconciler := NewObsykAgentReconciler(fakeClient, fakeClient, scheme, nil, "test-version")
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary
- Add version variable to `cmd/main.go` with ldflags support
- Update `NewObsykAgentReconciler` to accept version parameter
- Replace hard-coded `"0.1.0"` with dynamic version in controller
- Update Makefile to inject `GIT_VERSION` via ldflags for build and run targets
- Update Dockerfile to accept `VERSION` build arg
- Update `docker-build` and `docker-buildx` targets to pass version

## Details
The version is now set at build time using `git describe --tags --always --dirty`, which produces versions like:
- `v0.2.1` for tagged commits
- `v0.2.1-23-gabcdef0` for commits after a tag
- `v0.2.1-23-gabcdef0-dirty` for uncommitted changes
- `dev` as fallback when git is unavailable

This ensures the platform receives accurate version info in snapshot and heartbeat payloads.

Fixes #94

## Test plan
- [x] All existing tests pass with `make ci`
- [x] Version is correctly embedded in binary (verified with `strings bin/manager`)
- [x] Controller tests updated to pass version parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)