### PR TITLE
fix: regenerate CRD and add CI check for manifests

### DIFF
--- a/charts/obsyk-operator/crds/obsyk.io_obsykagents.yaml
+++ b/charts/obsyk-operator/crds/obsyk.io_obsykagents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: obsykagents.obsyk.io
 spec:
   group: obsyk.io
@@ -132,16 +132,8 @@ spec:
                 description: Conditions represent the latest available observations
                   of the agent's state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -182,12 +174,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -220,16 +207,90 @@ spec:
               resourceCounts:
                 description: ResourceCounts tracks the number of watched resources.
                 properties:
+                  clusterRoleBindings:
+                    description: ClusterRoleBindings is the count of cluster role
+                      bindings being watched.
+                    format: int32
+                    type: integer
+                  clusterRoles:
+                    description: ClusterRoles is the count of cluster roles being
+                      watched.
+                    format: int32
+                    type: integer
+                  configMaps:
+                    description: ConfigMaps is the count of configmaps being watched.
+                    format: int32
+                    type: integer
+                  cronJobs:
+                    description: CronJobs is the count of cronjobs being watched.
+                    format: int32
+                    type: integer
+                  daemonSets:
+                    description: DaemonSets is the count of daemonsets being watched.
+                    format: int32
+                    type: integer
+                  deployments:
+                    description: Deployments is the count of deployments being watched.
+                    format: int32
+                    type: integer
+                  events:
+                    description: Events is the count of events being watched.
+                    format: int32
+                    type: integer
+                  ingresses:
+                    description: Ingresses is the count of ingresses being watched.
+                    format: int32
+                    type: integer
+                  jobs:
+                    description: Jobs is the count of jobs being watched.
+                    format: int32
+                    type: integer
                   namespaces:
                     description: Namespaces is the count of namespaces being watched.
+                    format: int32
+                    type: integer
+                  networkPolicies:
+                    description: NetworkPolicies is the count of network policies
+                      being watched.
+                    format: int32
+                    type: integer
+                  nodes:
+                    description: Nodes is the count of nodes being watched.
                     format: int32
                     type: integer
                   pods:
                     description: Pods is the count of pods being watched.
                     format: int32
                     type: integer
+                  pvcs:
+                    description: PVCs is the count of persistent volume claims being
+                      watched.
+                    format: int32
+                    type: integer
+                  roleBindings:
+                    description: RoleBindings is the count of role bindings being
+                      watched.
+                    format: int32
+                    type: integer
+                  roles:
+                    description: Roles is the count of roles being watched.
+                    format: int32
+                    type: integer
+                  secrets:
+                    description: Secrets is the count of secrets being watched.
+                    format: int32
+                    type: integer
+                  serviceAccounts:
+                    description: ServiceAccounts is the count of service accounts
+                      being watched.
+                    format: int32
+                    type: integer
                   services:
                     description: Services is the count of services being watched.
+                    format: int32
+                    type: integer
+                  statefulSets:
+                    description: StatefulSets is the count of statefulsets being watched.
                     format: int32
                     type: integer
                 type: object

--- a/config/crd/bases/obsyk.io_obsykagents.yaml
+++ b/config/crd/bases/obsyk.io_obsykagents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: obsykagents.obsyk.io
 spec:
   group: obsyk.io
@@ -132,16 +132,8 @@ spec:
                 description: Conditions represent the latest available observations
                   of the agent's state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -182,12 +174,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -220,16 +207,90 @@ spec:
               resourceCounts:
                 description: ResourceCounts tracks the number of watched resources.
                 properties:
+                  clusterRoleBindings:
+                    description: ClusterRoleBindings is the count of cluster role
+                      bindings being watched.
+                    format: int32
+                    type: integer
+                  clusterRoles:
+                    description: ClusterRoles is the count of cluster roles being
+                      watched.
+                    format: int32
+                    type: integer
+                  configMaps:
+                    description: ConfigMaps is the count of configmaps being watched.
+                    format: int32
+                    type: integer
+                  cronJobs:
+                    description: CronJobs is the count of cronjobs being watched.
+                    format: int32
+                    type: integer
+                  daemonSets:
+                    description: DaemonSets is the count of daemonsets being watched.
+                    format: int32
+                    type: integer
+                  deployments:
+                    description: Deployments is the count of deployments being watched.
+                    format: int32
+                    type: integer
+                  events:
+                    description: Events is the count of events being watched.
+                    format: int32
+                    type: integer
+                  ingresses:
+                    description: Ingresses is the count of ingresses being watched.
+                    format: int32
+                    type: integer
+                  jobs:
+                    description: Jobs is the count of jobs being watched.
+                    format: int32
+                    type: integer
                   namespaces:
                     description: Namespaces is the count of namespaces being watched.
+                    format: int32
+                    type: integer
+                  networkPolicies:
+                    description: NetworkPolicies is the count of network policies
+                      being watched.
+                    format: int32
+                    type: integer
+                  nodes:
+                    description: Nodes is the count of nodes being watched.
                     format: int32
                     type: integer
                   pods:
                     description: Pods is the count of pods being watched.
                     format: int32
                     type: integer
+                  pvcs:
+                    description: PVCs is the count of persistent volume claims being
+                      watched.
+                    format: int32
+                    type: integer
+                  roleBindings:
+                    description: RoleBindings is the count of role bindings being
+                      watched.
+                    format: int32
+                    type: integer
+                  roles:
+                    description: Roles is the count of roles being watched.
+                    format: int32
+                    type: integer
+                  secrets:
+                    description: Secrets is the count of secrets being watched.
+                    format: int32
+                    type: integer
+                  serviceAccounts:
+                    description: ServiceAccounts is the count of service accounts
+                      being watched.
+                    format: int32
+                    type: integer
                   services:
                     description: Services is the count of services being watched.
+                    format: int32
+                    type: integer
+                  statefulSets:
+                    description: StatefulSets is the count of statefulsets being watched.
                     format: int32
                     type: integer
                 type: object

--- a/internal/ingestion/integration_test.go
+++ b/internal/ingestion/integration_test.go
@@ -419,7 +419,11 @@ func TestIntegration_GracefulShutdownWithPendingEvents(t *testing.T) {
 		_, _ = clientset.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
 	}
 
-	// Stop manager immediately - should drain remaining events
+	// Give informer time to queue events before stopping
+	// This prevents flaky failures in CI where events aren't queued yet
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop manager - should drain remaining events
 	mgr.Stop()
 
 	select {


### PR DESCRIPTION
## Summary
The CRD was not regenerated after adding new fields to the ResourceCounts struct in GH-88. This caused the Helm chart to ship with only 3 resourceCounts fields instead of all 20.

## Problem
- v0.3.0 Helm chart shipped with outdated CRD
- `status.resourceCounts` only showed namespaces, pods, services
- Missing: nodes, deployments, statefulSets, daemonSets, jobs, cronJobs, ingresses, networkPolicies, configMaps, secrets, pvcs, serviceAccounts, roles, clusterRoles, roleBindings, clusterRoleBindings, events
- No CI check to catch this drift

## Changes
- Regenerated CRD with all 20 resourceCounts fields
- Added `make verify-manifests` target to CI
- `make manifests` now auto-copies CRD to Helm chart
- CI will fail if CRD is out of sync with Go types
- Fixed flaky test `TestIntegration_GracefulShutdownWithPendingEvents` (fixes #111)
- Updated controller-gen from v0.14.0 to v0.19.0 (fixes Go tools compatibility)

## Test plan
- [x] CRD now has all 20 resourceCounts fields
- [x] Flaky test fixed with 100ms delay for event queueing
- [x] CI passes with new verify-manifests check

🤖 Generated with [Claude Code](https://claude.com/claude-code)