### PR TITLE
[GH-114] fix: add events list/watch RBAC for ingestion

### DIFF
--- a/charts/obsyk-operator/templates/clusterrole.yaml
+++ b/charts/obsyk-operator/templates/clusterrole.yaml
@@ -184,7 +184,7 @@ rules:
       - patch
       - update
       - watch
-  # Events for leader election announcements
+  # Events for leader election announcements and cluster event ingestion
   - apiGroups:
       - ""
     resources:
@@ -192,3 +192,5 @@ rules:
     verbs:
       - create
       - patch
+      - list
+      - watch


### PR DESCRIPTION
## Summary
- Added `list` and `watch` permissions for events to the ClusterRole
- This fixes the ingestion manager failing to start due to cache sync timeout

## Root Cause
The ingestion manager registers an Events informer but the ClusterRole only had `create`/`patch` permissions (for leader election). This caused:
1. Events informer failed with RBAC error: `events is forbidden: User cannot list resource "events" at the cluster scope`
2. Cache sync timed out after 60 seconds waiting for Events informer
3. Ingestion manager stopped and set `started = false`
4. Controller looped forever "waiting for ingestion manager to start"
5. No heartbeats sent, platform showed cluster as disconnected

## Test plan
- [x] Helm upgrade applied RBAC changes
- [x] Operator restarted and ingestion manager synced successfully
- [x] resourceCounts now includes `events: 46`
- [x] No more RBAC errors in logs
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)